### PR TITLE
Fix `ory-dev` invocation when generating sdks

### DIFF
--- a/scripts/prep.sh
+++ b/scripts/prep.sh
@@ -32,7 +32,7 @@ echo "Generating SDKs for $project:$version"
 spec_file="spec/${project}/${version}.json"
 
 ## Update version string in the spec file ##
-ory-dev swagger sanitize "../${spec_file}"
+ory-dev swagger sanitize "${spec_file}"
 swagger validate "${spec_file}"
 
 jq -c ".info.version = \"${version}\"" "${spec_file}" > tmp.$$.json && mv tmp.$$.json "${spec_file}"


### PR DESCRIPTION
When calling `./scripts/generate.sh` script encounters an error due to redundant `..` present in `ory-dev` invocation