### PR TITLE
Form field value from object to string

### DIFF
--- a/clients/kratos/typescript/model/formField.ts
+++ b/clients/kratos/typescript/model/formField.ts
@@ -41,7 +41,7 @@ export class FormField {
     /**
     * Value is the equivalent of `<input value=\"{{.Value}}\">`
     */
-    'value'?: object;
+    'value'?: string;
 
     static discriminator: string | undefined = undefined;
 


### PR DESCRIPTION
I understand that this has been auto generated so the PR will probably be declined, but I thought I'd bring this to your attention. I'm always getting a string type on `value` when handling login or registration requests. I think this might be a type error.