### PR TITLE
feat: add dotnet SDK generation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,19 @@ RUN npm install @openapitools/openapi-generator-cli -g
 RUN python3 -m pip install --upgrade pip
 RUN python3 -m pip install --user --upgrade setuptools wheel twine
 
+# dotnet
+ENV PATH "$PATH:/root/.dotnet"
+
+RUN apk add --no-cache --virtual .build-deps \
+    lttng-ust-dev \
+    icu-libs \
+    zlib \
+    && wget -O dotnet-install.sh https://dot.net/v1/dotnet-install.sh \
+    && chmod +x dotnet-install.sh \
+    && ./dotnet-install.sh --channel Current \
+    && apk del .build-deps \
+    && rm dotnet-install.sh
+
 RUN download_url=$(curl -s https://api.github.com/repos/go-swagger/go-swagger/releases/latest | \
       jq -r '.assets[] | select(.name | contains("'"$(uname | tr '[:upper:]' '[:lower:]')"'_amd64")) | .browser_download_url') \
     && curl -o /usr/local/bin/swagger -L'#' "$download_url" \

--- a/config/client/dotnet.yml
+++ b/config/client/dotnet.yml
@@ -1,3 +1,4 @@
+licenseId: Apache-2.0
 packageName: "Ory.$PROJECT_UCF.Client"
 packageVersion: $VERSION
 packageAuthors: ORY

--- a/config/client/dotnet.yml
+++ b/config/client/dotnet.yml
@@ -1,0 +1,6 @@
+packageName: "Ory.$PROJECT_UCF.Client"
+packageVersion: $VERSION
+packageAuthors: ORY
+packageCompany: ORY GmbH
+netCoreProjectFile: true
+infoUrl: https://www.ory.sh

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -19,12 +19,14 @@ cleanup() {
   rm "clients/${PROJECT}/python/git_push.sh" || true
   rm "clients/${PROJECT}/ruby/git_push.sh" || true
   rm "clients/${PROJECT}/typescript/git_push.sh" || true
+  rm "clients/${PROJECT}/dotnet/git_push.sh" || true
 
   rm "clients/${PROJECT}/java/.travis.yml" || true
   rm "clients/${PROJECT}/php/.travis.yml" || true
   rm "clients/${PROJECT}/python/.travis.yml" || true
   rm "clients/${PROJECT}/ruby/.travis.yml" || true
   rm "clients/${PROJECT}/typescript/.travis.yml" || true
+  rm "clients/${PROJECT}/dotnet/.travis.yml" || true
 }
 
 typescript () {
@@ -177,6 +179,19 @@ golang () {
   swagger generate client --allow-template-override -f "${SPEC_FILE}" -t "${dir}" -A "Ory_${PROJECT_UCF}"
 }
 
+dotnet () {
+  echo "Generating dotnet..."
+
+  dir="clients/${PROJECT}/dotnet"
+
+  openapi-generator generate -i "${SPEC_FILE}" \
+    -g csharp-netcore \
+    -o "$dir" \
+    --git-user-id ory \
+    --git-repo-id sdk \
+    --git-host github.com \
+    -c ./config/client/dotnet.yml.proc.yml
+}
 
 golang
 typescript
@@ -184,5 +199,6 @@ java
 php
 python
 ruby
+dotnet
 
 cleanup

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -102,11 +102,27 @@ python() {
   (cd "${dir}"; rm -rf "dist" || true; python3 setup.py sdist bdist_wheel; python3 -m twine upload "dist/*")
 }
 
+dotnet() {
+  to_git "dotnet" "no"
+
+  gitdir="clients/${PROJECT}-client-dotnet"
+  version=$(echo "${VERSION}" | sed "s/^v//")
+
+  (cd "${gitdir}"; dotnet pack)
+
+  (cd "${gitdir}"; dotnet nuget push Ory.${$PROJECT_UCF}.Client.${version}.nupkg \
+  --api-key ${NUGET_API_KEY} \
+  --source https://api.nuget.org/v3/index.json)
+
+  (cd "${gitdir}"; git push origin --tags HEAD:master)
+}
+
 java
 python
 ruby
 golang
 php
 typescript
+dotnet
 
 upstream


### PR DESCRIPTION
Started work on generating and pushing a dotnet package to NuGet.

This requires the `NUGET_API_KEY` environment variable to be set in CI as well as the `Ory` org to be claimed at NuGet.

Any guidance on how to test this implementation would be good, it should work right away but I haven't found a way to test it.