### PR TITLE
fix: recursion in dotnet sdk generation

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -106,9 +106,9 @@ dotnet() {
   dir="clients/${PROJECT}/dotnet"
   version=$(echo "${VERSION}" | sed "s/^v//")
 
-  (cd "${dir}"; dotnet pack)
+  (cd "${dir}"; command dotnet pack)
 
-  (cd "${dir}"; dotnet nuget push Ory.${PROJECT_UCF}.Client.${version}.nupkg \
+  (cd "${dir}"; command dotnet nuget push Ory.${PROJECT_UCF}.Client.${version}.nupkg \
   --api-key ${NUGET_API_KEY} \
   --source https://api.nuget.org/v3/index.json)
 }


### PR DESCRIPTION
I overlooked some recursion in the generation of the dotnet sdks. Who thought it would be a good idea to name the cli the same thing as the platform? 🤦‍♂️ (it's totally my own fault and it makes complete sense but this was surprisingly hard to spot 😂)

It's calling itself here: https://github.com/ory/sdk/blob/master/scripts/release.sh#L109

and here: https://github.com/ory/sdk/blob/master/scripts/release.sh#L111

