### PR TITLE
Add ARM docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,40 +1,29 @@
-FROM openjdk:12-alpine
+FROM openjdk:16-slim-buster
 
-RUN apk add --no-cache \
-		ca-certificates
-
-# set up nsswitch.conf for Go's "netgo" implementation
-# - https://github.com/golang/go/blob/go1.9.1/src/net/conf.go#L194-L275
-# - docker run --rm debian:stretch grep '^hosts:' /etc/nsswitch.conf
-RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
+RUN apt-get update; apt-get install -y --no-install-recommends ca-certificates
 
 ENV GOLANG_VERSION 1.15.6
 
 RUN set -eux; \
-	apk add --no-cache --virtual .build-deps \
-		bash \
-		gcc \
-		musl-dev \
-		openssl \
-		go \
-	; \
+	apt-get install -y --no-install-recommends bash build-essential openssl golang-go curl wget; \
+	rm -rf /var/lib/apt/lists/*; \
 	export \
-# set GOROOT_BOOTSTRAP such that we can actually build Go
-		GOROOT_BOOTSTRAP="$(go env GOROOT)" \
-# ... and set "cross-building" related vars to the installed system's values so that we create a build targeting the proper arch
-# (for example, if our build host is GOARCH=amd64, but our build env/image is GOARCH=386, our build needs GOARCH=386)
-		GOOS="$(go env GOOS)" \
-		GOARCH="$(go env GOARCH)" \
-		GOHOSTOS="$(go env GOHOSTOS)" \
-		GOHOSTARCH="$(go env GOHOSTARCH)" \
+	# set GOROOT_BOOTSTRAP such that we can actually build Go
+	GOROOT_BOOTSTRAP="$(go env GOROOT)" \
+	# ... and set "cross-building" related vars to the installed system's values so that we create a build targeting the proper arch
+	# (for example, if our build host is GOARCH=amd64, but our build env/image is GOARCH=386, our build needs GOARCH=386)
+	GOOS="$(go env GOOS)" \
+	GOARCH="$(go env GOARCH)" \
+	GOHOSTOS="$(go env GOHOSTOS)" \
+	GOHOSTARCH="$(go env GOHOSTARCH)" \
 	; \
-# also explicitly set GO386 and GOARM if appropriate
-# https://github.com/docker-library/golang/issues/184
-	apkArch="$(apk --print-arch)"; \
-	case "$apkArch" in \
-		armhf) export GOARM='6' ;; \
-		armv7) export GOARM='7' ;; \
-		x86) export GO386='387' ;; \
+	# also explicitly set GO386 and GOARM if appropriate
+	# https://github.com/docker-library/golang/issues/184
+	dpkgArch="$(dpkg --print-architecture)"; \
+	case "$dpkgArch" in \
+	armhf) export GOARM='6' ;; \
+	armv7) export GOARM='7' ;; \
+	x86) export GO386='387' ;; \
 	esac; \
 	\
 	wget -O go.tgz "https://golang.org/dl/go$GOLANG_VERSION.src.tar.gz"; \
@@ -45,13 +34,12 @@ RUN set -eux; \
 	./make.bash; \
 	\
 	rm -rf \
-# https://github.com/golang/go/blob/0b30cf534a03618162d3015c8705dd2231e34703/src/cmd/dist/buildtool.go#L121-L125
-		/usr/local/go/pkg/bootstrap \
-# https://golang.org/cl/82095
-# https://github.com/golang/build/blob/e3fe1605c30f6a3fd136b561569933312ede8782/cmd/release/releaselet.go#L56
-		/usr/local/go/pkg/obj \
+	# https://github.com/golang/go/blob/0b30cf534a03618162d3015c8705dd2231e34703/src/cmd/dist/buildtool.go#L121-L125
+	/usr/local/go/pkg/bootstrap \
+	# https://golang.org/cl/82095
+	# https://github.com/golang/build/blob/e3fe1605c30f6a3fd136b561569933312ede8782/cmd/release/releaselet.go#L56
+	/usr/local/go/pkg/obj \
 	; \
-	apk del .build-deps; \
 	\
 	export PATH="/usr/local/go/bin:$PATH"; \
 	go version
@@ -61,31 +49,36 @@ ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 ENV GO111MODULE=on
 
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
-RUN apk add -U --no-cache ca-certificates bash nodejs npm python3 python3-dev py-pip ruby jq build-base gnupg git openssh curl gettext libffi libffi-dev openssl-dev php composer php-curl php7-tokenizer wget php-dom php-xml php-simplexml php-xmlwriter maven
+RUN curl -sL https://deb.nodesource.com/setup_15.x | bash - && apt-get install -y nodejs
+# the following is a workaround for openjdk-11-jre-headless erroring due to not having a man path in slim-debian
+RUN mkdir /usr/share/man/man1/
+RUN apt-get install -y --no-install-recommends python3 python3-dev python3-pip ruby jq gnupg git gettext libffi6 libffi-dev libssl-dev php composer php-curl php7.3-tokenizer php-dom php-xml php-simplexml php-xmlwriter maven
 
 # RUN wget http://central.maven.org/maven2/org/openapitools/openapi-generator-cli/4.2.2/openapi-generator-cli-4.2.2.jar -O openapi-generator-cli.jar
 
 RUN npm i -g @openapitools/openapi-generator-cli
 RUN openapi-generator-cli version-manager set 5.0.0
-RUN python3 -m pip install --upgrade pip
-RUN python3 -m pip install --user --upgrade setuptools wheel twine
+RUN pip3 install --upgrade pip
+RUN pip3 install --user --upgrade setuptools wheel twine
 
 # dotnet
 ENV PATH "$PATH:/root/.dotnet"
 
-RUN apk add --no-cache \
-    lttng-ust-dev \
-    icu-libs \
-    zlib \
-    && wget -O dotnet-install.sh https://dot.net/v1/dotnet-install.sh \
-    && chmod +x dotnet-install.sh \
-    && ./dotnet-install.sh --channel Current \
-    && rm dotnet-install.sh
+RUN apt-get install -y --no-install-recommends \
+	liblttng-ust-dev \
+	libicu-dev \
+	zlib1g \
+	&& wget -O dotnet-install.sh https://dot.net/v1/dotnet-install.sh \
+	&& chmod +x dotnet-install.sh \
+	&& ./dotnet-install.sh --channel Current \
+	&& rm dotnet-install.sh
+
+RUN rm -rf /var/lib/apt/lists/*
 
 RUN download_url=$(curl -s https://api.github.com/repos/go-swagger/go-swagger/releases/latest | \
-      jq -r '.assets[] | select(.name | contains("'"$(uname | tr '[:upper:]' '[:lower:]')"'_amd64")) | .browser_download_url') \
-    && curl -o /usr/local/bin/swagger -L'#' "$download_url" \
-    && chmod +x /usr/local/bin/swagger
+	jq -r '.assets[] | select(.name | contains("'"$(uname | tr '[:upper:]' '[:lower:]')"'_amd64")) | .browser_download_url') \
+	&& curl -o /usr/local/bin/swagger -L'#' "$download_url" \
+	&& chmod +x /usr/local/bin/swagger
 
 ADD go.mod go.mod
 ADD go.sum go.sum

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -34,7 +34,7 @@ typescript () {
 
   dir="clients/${PROJECT}/typescript"
 
-  openapi-generator generate -i "${SPEC_FILE}" \
+  openapi-generator-cli generate -i "${SPEC_FILE}" \
     -g typescript-axios \
     -o "$dir" \
     --git-user-id ory \
@@ -57,7 +57,7 @@ java () {
   rm -rf "${dir}/src" || true
   rm -rf "${dir}/docs" || true
 
-  openapi-generator generate -i "${SPEC_FILE}" \
+  openapi-generator-cli generate -i "${SPEC_FILE}" \
     -g java \
     -o "$dir" \
     --git-user-id ory \
@@ -117,7 +117,7 @@ php() {
 
   dir="clients/${PROJECT}/php"
 
-  openapi-generator generate -i "${SPEC_FILE}" \
+  openapi-generator-cli generate -i "${SPEC_FILE}" \
     -g php \
     -o "$dir" \
     --git-user-id ory \
@@ -138,7 +138,7 @@ python () {
 
   dir="clients/${PROJECT}/python"
 
-  openapi-generator generate -i "${SPEC_FILE}" \
+  openapi-generator-cli generate -i "${SPEC_FILE}" \
     -g python \
     -o "$dir" \
     --git-user-id ory \
@@ -154,7 +154,7 @@ ruby () {
 
   rm "${dir}/lib/ory-${PROJECT}-client/version.rb" || true
 
-  openapi-generator generate -i "${SPEC_FILE}" \
+  openapi-generator-cli generate -i "${SPEC_FILE}" \
     -g ruby \
     -o "$dir" \
     --git-user-id ory \
@@ -184,7 +184,7 @@ dotnet () {
 
   dir="clients/${PROJECT}/dotnet"
 
-  openapi-generator generate -i "${SPEC_FILE}" \
+  openapi-generator-cli generate -i "${SPEC_FILE}" \
     -g csharp-netcore \
     -o "$dir" \
     --model-name-prefix ${PROJECT_UCF} \


### PR DESCRIPTION
This changes the Docker container to build off of `openjdk:16-slim-buster` to add ARM support for local testing on new Apple M1 silicon.

This addresses points raised in #48. 