### PR TITLE
Update SDK link

### DIFF
--- a/clients/kratos/rust/Cargo.toml
+++ b/clients/kratos/rust/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "ory-kratos-client"
 version = "0.6.0-alpha.17"
-description = "SDK Client for ORY Keto"
-documentation = "https://www.ory.sh/keto/docs/sdk"
+description = "SDK Client for ORY Kratos"
+documentation = "https://www.ory.sh/kratos/docs/sdk/"
 homepage = "https://www.ory.sh"
 license = "Apache-2.0"
 authors = ["OpenAPI Generator team and contributors"]


### PR DESCRIPTION
This fixes the link to the sdk documentation on crates.io