### PR TITLE
fix: Generate proper module name for Ruby clients

### DIFF
--- a/config/client/ruby.yml
+++ b/config/client/ruby.yml
@@ -7,4 +7,4 @@ gemAuthorEmail: opensource@ory.sh
 gemAuthor: ORY GmbH
 gemHomepage: https://www.ory.sh
 gemLicense: Apache-2.0
-moduleName: OryHydraClient
+moduleName: ${RUBY_MODULE_NAME}

--- a/scripts/prep.sh
+++ b/scripts/prep.sh
@@ -70,6 +70,7 @@ export PYTHON_PROJECT_NAME="ory-${PROJECT}-client"
 export PYTHON_PACKAGE_NAME="ory_${PROJECT}_client"
 
 export RUBY_PROJECT_NAME="ory-${PROJECT}-client"
+export RUBY_MODULE_NAME="Ory${PROJECT_UCF}Client"
 
 export RUST_PACKAGE_NAME="ory-${PROJECT}-client"
 
@@ -91,7 +92,7 @@ if [ $project == "client" ]; then
   export PYTHON_PACKAGE_NAME="ory_client"
 
   export RUBY_PROJECT_NAME="ory-client"
-  export RUBY_PROJECT_NAME="ory-client"
+  export RUBY_MODULE_NAME="OryClient"
 
   export RUST_PACKAGE_NAME="ory-client"
 


### PR DESCRIPTION
All ruby clients are generated with a hard-coded module name "OryHydraClient", which is wrong.
For instance for Kratos client:
```ruby
# Actual
module OryHydraClient
  class << self
    # ...
  end
end

# Expected
module OryKratosClient
  class << self
    # ...
  end
end
```

This PR fixes it for all clients.


- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added necessary documentation within the code base (if
      appropriate).