### PR TITLE
chore: update repository template to ed8a3628

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,8 +33,8 @@ of this document is to provide a high-level overview of how you can get
 involved.
 
 _Please note_: We take Ory Ory SDK's security and our users' trust very
-seriously. If you believe you have found a security issue in Ory Ory SDK, please
-responsibly disclose by contacting us at security@ory.sh.
+seriously. If you believe you have found a security issue in Ory Ory SDK,
+please responsibly disclose by contacting us at security@ory.sh.
 
 First: As a potential contributor, your changes and ideas are welcome at any
 hour of the day or night, weekdays, weekends, and holidays. Please do not ever
@@ -47,8 +47,10 @@ contributions, and don't want a wall of rules to get in the way of that.
 
 That said, if you want to ensure that a pull request is likely to be merged,
 talk to us! You can find out our thoughts and ensure that your contribution
-won't clash or be obviated by Ory Ory SDK's normal direction. A great way to do
-this is via [Ory Ory SDK Discussions](https://github.com/ory/meta/discussions)
+won't clash or be obviated by Ory
+Ory SDK's normal direction. A great way to
+do this is via
+[Ory Ory SDK Discussions](https://github.com/ory/meta/discussions)
 or the [Ory Chat](https://www.ory.sh/chat).
 
 ## FAQ
@@ -66,7 +68,8 @@ or the [Ory Chat](https://www.ory.sh/chat).
 - I want to talk to other Ory Ory SDK users.
   [How can I become a part of the community?](#communication)
 
-- I would like to know what I am agreeing to when I contribute to Ory Ory SDK.
+- I would like to know what I am agreeing to when I contribute to Ory
+  Ory SDK.
   Does Ory have
   [a Contributors License Agreement?](https://cla-assistant.io/ory/sdk)
 
@@ -90,8 +93,8 @@ a few things you can do to help out:
   look at discussions in the forum and take part in our weekly hangout. More
   info on this in [Communication](#communication).
 
-- **Helping with open issues.** We have a lot of open issues for Ory Ory SDK and
-  some of them may lack necessary information, some are duplicates of older
+- **Helping with open issues.** We have a lot of open issues for Ory Ory SDK
+  and some of them may lack necessary information, some are duplicates of older
   issues. You can help out by guiding people through the process of filling out
   the issue template, asking for clarifying information, or pointing them to
   existing issues that match their description of the problem.
@@ -99,7 +102,7 @@ a few things you can do to help out:
 - **Reviewing documentation changes.** Most documentation just needs a review
   for proper spelling and grammar. If you think a document can be improved in
   any way, feel free to hit the `edit` button at the top of the page. More info
-  on contributing to documentation here.
+  on contributing to documentation [here](#documentation).
 
 - **Help with tests.** Some pull requests may lack proper tests or test plans.
   These are needed for the change to be implemented safely.
@@ -109,9 +112,8 @@ a few things you can do to help out:
 We use [Slack](https://www.ory.sh/chat). You are welcome to drop in and ask
 questions, discuss bugs and feature requests, talk to other users of Ory, etc.
 
-Check out [Ory Ory SDK Discussions](https://github.com/ory/meta/discussions).
-This is a great place for in-depth discussions and lots of code examples, logs
-and similar data.
+Check out [Ory Ory SDK Discussions](https://github.com/ory/meta/discussions). This is a great place for
+in-depth discussions and lots of code examples, logs and similar data.
 
 You can also join our community hangout, if you want to speak to the Ory team
 directly or ask some questions. You can find more info on the hangouts in


### PR DESCRIPTION
Updated repository templates to https://github.com/ory/meta/commit/ed8a36281e6aeb1680630c97a66b691d04ed7457.