### PR TITLE
fix: generate with dart instead of dart-dio [dart] 

### DIFF
--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -243,7 +243,7 @@ dart () {
 
   openapi-generator-cli version-manager set 6.0.1
   openapi-generator-cli generate -i "${SPEC_FILE}" \
-    -g dart-dio \
+    -g dart \
     -o "$dir" \
     --git-user-id ory \
     --git-repo-id sdk \


### PR DESCRIPTION
## Description
Current ory sdk for dart generation uses `dart-dio` which does not support null safety intrduced in Dart 2.12. As Flutter 3 requires Dart's null safety, it is a blocking issue for the ory sdk to not support Flutter 3. The change uses the "default" Dart generator `dart` instead of `dart-dio` 

## Related Issue or Design Document
Ory & Dart's null safety is discussed here https://github.com/ory/cloud/issues/13

## Checklist
- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [X] I have read the [security policy](../security/policy).
- [X] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation within the code base (if appropriate).

## Further comments

Full disclosure I have not tested generating Ory SDK with `dart` over `dart-dio` 🙊 