### PR TITLE
feat: use dart-dio now that it supports polymorphism

### DIFF
--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -242,9 +242,9 @@ dart () {
   rm -rf "$dir" || true
   mkdir -p "$dir"
 
-  openapi-generator-cli version-manager set 6.0.1
+  openapi-generator-cli version-manager set 6.1.0
   openapi-generator-cli generate -i "${SPEC_FILE}" \
-    -g dart \
+    -g dart-dio \
     -o "$dir" \
     --git-user-id ory \
     --git-repo-id sdk \


### PR DESCRIPTION
## Description
After months of work `dart-dio` has been updated with furthered support of OAS3 https://github.com/OpenAPITools/openapi-generator/pull/12295

It would be in user's interest to use the more encompassing dart generator leveraging dio (replacement of dart's http pkg) with OAS3 polymorphism support

## Related Issue or Design Document
Previous PR to switch off `dart-dio` due to issues with not generating flutter 3 compatible code https://github.com/ory/sdk/pull/202

## Checklist
- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [X] I have read the [security policy](../security/policy).
- [X] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation within the code base (if appropriate).

## Further comments

Full disclosure I have not tested generating Ory SDK with `dart` over `dart-dio` 🙊 