### PR TITLE
fix: python client scope field type

### DIFF
--- a/clients/hydra/python/ory_hydra_client/model/o_auth2_token_exchange.py
+++ b/clients/hydra/python/ory_hydra_client/model/o_auth2_token_exchange.py
@@ -86,7 +86,7 @@ class OAuth2TokenExchange(ModelNormal):
             'expires_in': (int,),  # noqa: E501
             'id_token': (int,),  # noqa: E501
             'refresh_token': (str,),  # noqa: E501
-            'scope': (int,),  # noqa: E501
+            'scope': (str,),  # noqa: E501
             'token_type': (str,),  # noqa: E501
         }
 


### PR DESCRIPTION
## Proposed fix for #220

As described in the issue post, after the update to version 2.0.1, the hydra python client had a misconfiguration which caused the token change flow not to work at all. This had to do with the type of the "scope" value the client expects to receive from hydra.

Based on the documentation and the OAuth2 standard, the scope field should be a **string** value containing space-separated entries. Instead, the new client update proposed it to have a value of **int**, thus causing the client not to work properly with hydra because of this type mismatch.

## Tests

I have applied this proposed change on my local hydra python client and I can confirm it works as expected with hydra v2.0.1.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation within the code base (if appropriate).
