### PR TITLE
fix: update SDK READMEs

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -10,6 +10,14 @@ changes to this repository will be overwritten on the next CI run!
 
 ${INSTALL}
 
+## Documentation
+
+- [Ory Network](https://www.ory.sh/docs/sdk)
+- [Ory Hydra](https://www.ory.sh/hydra/docs/sdk)
+- [Ory Kratos](https://www.ory.sh/kratos/docs/sdk)
+- [Ory Keto](https://www.ory.sh/keto/docs/sdk)
+- [Ory Oathkeeper](https://www.ory.sh/oathkeeper/docs/sdk)
+
 ## Generation
 
 This code base, including this README, is auto-generated using
@@ -18,19 +26,11 @@ please check if there is an open issue at
 [OpenAPITools/openapi-generator](https://github.com/OpenAPITools/openapi-generator)
 or [ory/sdk](http://github.com/ory/sdk) already before opening an issue here.
 
-If you have general feedback on the generated SDK please open an issue in
-[ory/sdk](http://github.com/ory/sdk).
+## Feedback
 
-## Documentation
+If you have feedback on how to improve the Ory SDK or are
+[looking to contribute](https://www.ory.sh/docs/ecosystem/contributing), please
+[open an issue](https://github.com/ory/sdk/issues/new/choose) in `ory/sdk` to
+discuss your ideas.
 
-Unfortunately this SDK is not yet documented. If you are looking for
-contributing documentation please open an issue first to discuss your ideas. We
-are greatly appreciating any help!
-
-In the meanwhile, check out the meta-documentation for Ory's SDKs:
-
-- [Ory Cloud](https://www.ory.sh/docs/start-building/other-languages)
-- [Ory Hydra](https://www.ory.sh/hydra/docs/sdk)
-- [Ory Kratos](https://www.ory.sh/kratos/docs/sdk)
-- [Ory Keto](https://www.ory.sh/keto/docs/sdk)
-- [Ory Oathkeeper](https://www.ory.sh/oathkeeper/docs/sdk)
+Thanks for being a part of the Ory community!


### PR DESCRIPTION
Context: https://github.com/ory/client-ruby/issues/2#issuecomment-1372826023

- make the documentation links more prominent in the SDK READMEs
- update to Ory Network + correct link
- move feedback to the end of document

This should lead all who are looking for docs to ory.sh/docs/sdk where there will be a table overview of all SDKs and their docs. 


closes: https://github.com/ory/client-ruby/issues/2