### PR TITLE
fix: pin ruby `bundler` gem to v`2.3.36`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -122,7 +122,7 @@ RUN td=$(mktemp) \
     && chmod +x /usr/local/bin/gh \
     && rm -rf $td $tdd
 
-RUN gem install bundler && \
+RUN gem install bundler -v 2.3.26 && \
       apt-get update && \
       apt-get install -y --no-install-recommends ruby-dev
 


### PR DESCRIPTION
Was previously failing to build the docker image with
```
 => ERROR [20/25] RUN gem install bundler &&       apt-get update &&       apt-get install -y --no-install-recommends ruby-dev                                                                                                                                            3.4s
------
 > [20/25] RUN gem install bundler &&       apt-get update &&       apt-get install -y --no-install-recommends ruby-dev:
------
executor failed running [/bin/sh -c gem install bundler &&       apt-get update &&       apt-get install -y --no-install-recommends ruby-dev]: exit code: 1
```

## Related Issue or Design Document

None.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation within the code base (if appropriate).
