### PR TITLE
fix:  use headers instead of deprecated getheaders() in urllib3 (Python SDK)

### DIFF
--- a/clients/client/python/ory_client/rest.py
+++ b/clients/client/python/ory_client/rest.py
@@ -36,7 +36,7 @@ class RESTResponse(io.IOBase):
 
     def getheaders(self):
         """Returns a dictionary of the response headers."""
-        return self.urllib3_response.getheaders()
+        return self.urllib3_response.headers
 
     def getheader(self, name, default=None):
         """Returns a given response header."""

--- a/clients/hydra/python/ory_hydra_client/rest.py
+++ b/clients/hydra/python/ory_hydra_client/rest.py
@@ -36,7 +36,7 @@ class RESTResponse(io.IOBase):
 
     def getheaders(self):
         """Returns a dictionary of the response headers."""
-        return self.urllib3_response.getheaders()
+        return self.urllib3_response.headers
 
     def getheader(self, name, default=None):
         """Returns a given response header."""

--- a/clients/keto/python/ory_keto_client/rest.py
+++ b/clients/keto/python/ory_keto_client/rest.py
@@ -36,7 +36,7 @@ class RESTResponse(io.IOBase):
 
     def getheaders(self):
         """Returns a dictionary of the response headers."""
-        return self.urllib3_response.getheaders()
+        return self.urllib3_response.headers
 
     def getheader(self, name, default=None):
         """Returns a given response header."""

--- a/clients/kratos/python/ory_kratos_client/rest.py
+++ b/clients/kratos/python/ory_kratos_client/rest.py
@@ -36,7 +36,7 @@ class RESTResponse(io.IOBase):
 
     def getheaders(self):
         """Returns a dictionary of the response headers."""
-        return self.urllib3_response.getheaders()
+        return self.urllib3_response.headers
 
     def getheader(self, name, default=None):
         """Returns a given response header."""

--- a/clients/oathkeeper/python/ory_oathkeeper_client/rest.py
+++ b/clients/oathkeeper/python/ory_oathkeeper_client/rest.py
@@ -36,7 +36,7 @@ class RESTResponse(io.IOBase):
 
     def getheaders(self):
         """Returns a dictionary of the response headers."""
-        return self.urllib3_response.getheaders()
+        return self.urllib3_response.headers
 
     def getheader(self, name, default=None):
         """Returns a given response header."""


### PR DESCRIPTION
In urllib3 the use of `getheaders()` method is deprecated:
```python
DeprecationWarning: HTTPResponse.getheaders() is deprecated and will be removed in urllib3 v2.1.0. Instead access HTTPResponse.headers directly.
```
Calls to `self.urllib3_response.getheaders()` should be replaced with `self.urllib3_response.headers` to fix this warning.

This pull request fixes the usage of `getheaders()` by removing the usage of the deprecated method.

## Related Issue or Design Document

See the above description for the issue explaination.

## Checklist

- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [X] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.

## Further comments

None
