### PR TITLE
feat(ts): use native fetch instead of axios

### DIFF
--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -43,7 +43,7 @@ typescript () {
 
   openapi-generator-cli version-manager set 7.2.0
   openapi-generator-cli generate -i "${SPEC_FILE}" \
-    -g typescript-axios \
+    -g typescript-fetch \
     -o "$dir" \
     --git-user-id ory \
     --git-repo-id sdk \


### PR DESCRIPTION
With Node 18 having native support for the fetch API, there is no need anymore to have a separate library for network communication.

This PR switches the typescript-axios generator out against the typescript-fetch one. If backward compatibility for older node versions is still wanted, this could instead be released as a separate package (@ory/client-fetch).

This would hugely benefit frontend projects, as users would have to download one dependency less, thus reducing loading times.

BREAKING CHANGES: This patch requires a fetch polyfill on NodeJS versions 16 and lower.

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation within the code base (if appropriate).

## Further comments

https://github.com/ory/sdk/pull/256