### PR TITLE
feat: expose api client hooks for dotnet

### DIFF
--- a/contrib/dotnet/ApiClientHooks.cs
+++ b/contrib/dotnet/ApiClientHooks.cs
@@ -1,0 +1,28 @@
+using RestSharp;
+using System;
+
+namespace Ory.Client.Client
+{
+    public partial class ApiClient : ISynchronousClient, IAsynchronousClient
+    {
+        /// <summary>
+        /// Hook to access the underlying RestRequest before the request is sent.
+        /// </summary>
+        public Action<RestRequest>? RequestHook { get; set; }
+
+        /// <summary>
+        /// Hook to access the underlying RestRequest and RestResponse after the response is received.
+        /// </summary>
+        public Action<RestRequest, RestResponse>? ResponseHook { get; set; }
+
+        partial void InterceptRequest(RestRequest request)
+        {
+            RequestHook?.Invoke(request);
+        }
+
+        partial void InterceptResponse(RestRequest request, RestResponse response)
+        {
+            ResponseHook?.Invoke(request, response);
+        }
+    }
+}

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -227,6 +227,7 @@ dotnet () {
     --git-host github.com \
     -c ./config/client/dotnet.yml.proc.yml
   cp "LICENSE" "clients/${PROJECT}/dotnet"
+  cp "contrib/dotnet/ApiClientHooks.cs" "clients/${PROJECT}/dotnet/src/Ory.Client/Client"
 }
 
 dart () {


### PR DESCRIPTION
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a code block documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

When using Ory SDK from .NET Blazor WASM, it is necessary to call `httpRequestMessage.SetBrowserRequestCredentials(BrowserRequestCredentials.Include)` on `HttpRequestMessage` before invoking browser flows via fetch, so that cookies are included in the request and saved to the browser from the response.

Before making this PR I attempted to convince OpenAPI Generator maintainers to expose end-user-facing hooks on the generated `ApiClient`, but the implementation is taking time to work out. That is why this PR is for Ory SDK and not OpenAPI Generator.

This is a non-breaking change to add two new public properties to the `ApiClient` class `RequestHook` and `ResponseHook` which are optional actions to pre- and post-process RestClient roundtrips. This allows .NET Blazor WASM users to set a hook like so when creating a client. For example when using Kratos through `FrontendApi`:

```
var kratosURL = sp.GetService<IConfiguration>()?.GetValue<string>("Kratos:URL") ?? "";
var config = MergeConfigurations(
	Ory.Client.Client.GlobalConfiguration.Instance,
	new Ory.Client.Client.Configuration { BasePath = kratosURL }
);
static void includeCredentialsHook(RestRequest request)
{
	request.OnBeforeRequest = (HttpRequestMessage httpRequest) =>
	{
		httpRequest.SetBrowserRequestCredentials(BrowserRequestCredentials.Include);
		return ValueTask.CompletedTask;
	};
}
var syncClient = new ApiClient(kratosURL)
{
	RequestHook = includeCredentialsHook
};
var asyncClient = new ApiClient(kratosURL)
{
	RequestHook = includeCredentialsHook
};
return new FrontendApi(syncClient, asyncClient, config);
```

I've built and tested this change with my Blazor WASM project and it worked perfectly.

Please let me know if you require additional documentation or tests.

## Related Issue or Design Document

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation within the code base (if appropriate).



<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
