### PR TITLE
feat: add feature flag to support rustls-tls for rust client

### DIFF
--- a/clients/client/rust/Cargo.toml
+++ b/clients/client/rust/Cargo.toml
@@ -6,10 +6,15 @@ description = "OpenAPI API client for Ory Network, Ory's web-scale API for ident
 license = "Apache-2.0"
 edition = "2021"
 
+[features]
+default = ["reqwest"]
+rustls = ["reqwest_rustls"]
+
 [dependencies]
 serde = { version = "^1.0", features = ["derive"] }
 serde_with = { version = "^3.8", default-features = false, features = ["base64", "std", "macros"] }
 serde_json = "^1.0"
 url = "^2.5"
 uuid = { version = "^1.8", features = ["serde", "v4"] }
-reqwest = { version = "^0.12", features = ["json", "multipart"] }
+reqwest = { version = "^0.12", features = ["json", "multipart"], optional = true }
+reqwest_rustls = { package = "reqwest", version = "^0.12", default-features = false, features = ["json", "multipart", "rustls-tls", "brotli", "gzip"], optional = true }

--- a/clients/client/rust/src/lib.rs
+++ b/clients/client/rust/src/lib.rs
@@ -4,7 +4,10 @@
 extern crate serde;
 extern crate serde_json;
 extern crate url;
+#[cfg(feature = "default")]
 extern crate reqwest;
+#[cfg(feature = "rustls")]
+extern crate reqwest_rustls as reqwest;
 
 pub mod apis;
 pub mod models;


### PR DESCRIPTION
Due to the dependency on reqwest with it's default options, we have no way to replace openssl with rustls, which is an issue for our projects.

With this PR, I've added a feature flag that replaces openssl with rustls, while leaving the default on openssl. This ensures no breaking changes with previous versions and allows anyone to choose between their preferred TLS library.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [X] I have read the [security policy](../security/policy).
- [X] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added the necessary documentation within the code base (if
      appropriate).


