### PR TITLE
Fix #424

### DIFF
--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -225,7 +225,7 @@ dotnet () {
   rm -rf "$dir" || true
   mkdir -p "$dir"
 
-  npx @openapitools/openapi-generator-cli@2.17.0 version-manager set 7.11.0
+  npx @openapitools/openapi-generator-cli@2.17.0 version-manager set 7.12.0
   npx @openapitools/openapi-generator-cli@2.17.0 generate -i "${SPEC_FILE}" \
     -g csharp \
     -o "$dir" \


### PR DESCRIPTION
v7.12.0 changed the default csharp library to generichost, so updating the generator is all that is required.

See https://github.com/OpenAPITools/openapi-generator/releases/tag/v7.12.0

This PR fixes #424 

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [X] I have referenced an issue containing the design document if my change
      introduces a new feature. **Not applicable, not a new feature**
- [X] I have read the [security policy](../security/policy).
- [X] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [X] I have added tests that prove my fix is effective or that my feature
      works. **Not applicable, would expect unit tests within upstream `openapi-generator` codebase**
- [ ] I have added the necessary documentation within the code base (if
      appropriate).
  - Happy to be guided by maintainers' views here.

## Further comments

I am hopeful that the decision from upstream (openapi-generator) to change the default here will add some weight to the reasoning I provided in #424