### PR TITLE
chore: use openapi-generator 7.13 to generate rust client

### DIFF
--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -269,7 +269,7 @@ rust () {
   rm -rf "$dir" || true
   mkdir -p "$dir"
 
-  npx @openapitools/openapi-generator-cli@2.17.0 version-manager set 7.12.0
+  npx @openapitools/openapi-generator-cli@2.17.0 version-manager set 7.13.0
   npx @openapitools/openapi-generator-cli@2.17.0 generate -i "${SPEC_FILE}" \
     -g rust \
     -o "$dir" \


### PR DESCRIPTION
openapi generator 7.13 disables reqwest default features which turns off the openssl dependency.

## Related Issue or Design Document

#425 

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added the necessary documentation within the code base (if
      appropriate).
