### PR TITLE
typo: spelling mistake in README generation

### DIFF
--- a/scripts/prep.sh
+++ b/scripts/prep.sh
@@ -127,7 +127,7 @@ if [ $project == "client" ]; then
   export NETWORK_OR_SELFHOSTED="## Ory Network
 
 This SDK is for use with [Ory Network](https://www.ory.sh/docs/sdk).
-If you are developing aginst a self-hosted Ory instance, please use the individual ${PROJECT_UCF} SDK
+If you are developing against a self-hosted Ory instance, please use the individual ${PROJECT_UCF} SDK
 and refer to the [self-hosted documentation](https://www.ory.sh/docs/ecosystem/projects).
 
 "


### PR DESCRIPTION
Saw a typo in the [rust client's README.md](https://github.com/ory/client-rust/blob/f4af1100978e655db278f4a175e559adf7dca6cb/README.md?plain=1#L8).

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added the necessary documentation within the code base (if
      appropriate).

