### PR TITLE
docs: add Rust and csharp examples

### DIFF
--- a/clients/client/dotnet/docs/apis/ApiKeysApi.md
+++ b/clients/client/dotnet/docs/apis/ApiKeysApi.md
@@ -25,26 +25,60 @@ All URIs are relative to *https://playground.projects.oryapis.com*
 
 <a id="adminbatchcreateimportedapikeys"></a>
 # **AdminBatchCreateImportedApiKeys**
-> ClientBatchCreateImportedApiKeysResponse AdminBatchCreateImportedApiKeys (ClientBatchCreateImportedApiKeysRequest clientBatchCreateImportedApiKeysRequest)
+> Task&lt;IAdminBatchCreateImportedApiKeysApiResponse&gt; AdminBatchCreateImportedApiKeysAsync(ClientBatchCreateImportedApiKeysRequest clientBatchCreateImportedApiKeysRequest, System.Threading.CancellationToken cancellationToken = default)
 
 Batch Import API Keys
 
 Imports up to 1000 external API keys in one request. Returns per-item results. If at least one item succeeds, response is 200 OK. If all items fail, the endpoint returns a non-200 error.  ```http POST /v2alpha1/admin/importedApiKeys:batchCreate {   \"requests\": [     {\"raw_key\": \"sk_live_abc\", \"name\": \"Stripe key\", \"actor_id\": \"user_1\"},     {\"raw_key\": \"ghp_xyz\", \"name\": \"GitHub PAT\", \"actor_id\": \"user_2\"}   ] } ```
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class AdminBatchCreateImportedApiKeysExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IApiKeysApi>();
+            ClientBatchCreateImportedApiKeysRequest clientBatchCreateImportedApiKeysRequest = default!; // BatchCreateImportedApiKeysRequest imports multiple external API keys in one request. The maximum batch size is 1000 keys.
+            var response = await api.AdminBatchCreateImportedApiKeysAsync(clientBatchCreateImportedApiKeysRequest);
+            ClientBatchCreateImportedApiKeysResponse? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **clientBatchCreateImportedApiKeysRequest** | [**ClientBatchCreateImportedApiKeysRequest**](ClientBatchCreateImportedApiKeysRequest.md) | BatchCreateImportedApiKeysRequest imports multiple external API keys in one request. The maximum batch size is 1000 keys. |  |
+| **clientBatchCreateImportedApiKeysRequest** | [**ClientBatchCreateImportedApiKeysRequest**](../models/ClientBatchCreateImportedApiKeysRequest.md) | BatchCreateImportedApiKeysRequest imports multiple external API keys in one request. The maximum batch size is 1000 keys. |  |
 
 ### Return type
 
-[**ClientBatchCreateImportedApiKeysResponse**](ClientBatchCreateImportedApiKeysResponse.md)
+[**ClientBatchCreateImportedApiKeysResponse**](../models/ClientBatchCreateImportedApiKeysResponse.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -62,28 +96,64 @@ Imports up to 1000 external API keys in one request. Returns per-item results. I
 
 <a id="adminbatchverifyapikeys"></a>
 # **AdminBatchVerifyApiKeys**
-> ClientBatchVerifyApiKeysResponse AdminBatchVerifyApiKeys (ClientBatchVerifyApiKeysRequest clientBatchVerifyApiKeysRequest, string cacheControl = null, string pragma = null)
+> Task&lt;IAdminBatchVerifyApiKeysApiResponse&gt; AdminBatchVerifyApiKeysAsync(ClientBatchVerifyApiKeysRequest clientBatchVerifyApiKeysRequest, Option<string> cacheControl = default, Option<string> pragma = default, System.Threading.CancellationToken cancellationToken = default)
 
 Batch Verify API Keys
 
 Verifies multiple credentials in a single request. Efficiently verifies up to 100 credentials in parallel. Each credential is verified independently; partial failures are returned. Admin access only.  Cache Control (HTTP Headers):   - Cache-Control: no-cache  - Bypasses cache read, forces fresh DB lookup   - Cache-Control: no-store  - Bypasses cache read AND write (never cached)   - Pragma: no-cache         - Same as Cache-Control: no-cache (HTTP/1.0)  The cache directive applies to every credential in the batch.  ```http POST /v2alpha1/admin/apiKeys:batchVerify {   \"requests\": [     {\"credential\": \"sk_live_abc123...\"},     {\"credential\": \"eyJhbGciOiJFZERTQSI...\"}   ] } ```
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class AdminBatchVerifyApiKeysExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IApiKeysApi>();
+            ClientBatchVerifyApiKeysRequest clientBatchVerifyApiKeysRequest = default!; // 
+            Option<string> cacheControl = default!; // Cache-directive controlling the verifier cache. `no-cache` forces a fresh database lookup (cache read is bypassed). `no-store` additionally prevents the result from being written to the cache. Any other value is ignored. (optional)
+            Option<string> pragma = default!; // HTTP/1.0 alias for `Cache-Control: no-cache`. Behaves identically when set to `no-cache`; ignored otherwise. (optional)
+            var response = await api.AdminBatchVerifyApiKeysAsync(clientBatchVerifyApiKeysRequest, cacheControl, pragma);
+            ClientBatchVerifyApiKeysResponse? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **clientBatchVerifyApiKeysRequest** | [**ClientBatchVerifyApiKeysRequest**](ClientBatchVerifyApiKeysRequest.md) |  |  |
+| **clientBatchVerifyApiKeysRequest** | [**ClientBatchVerifyApiKeysRequest**](../models/ClientBatchVerifyApiKeysRequest.md) |  |  |
 | **cacheControl** | **string** | Cache-directive controlling the verifier cache. &#x60;no-cache&#x60; forces a fresh database lookup (cache read is bypassed). &#x60;no-store&#x60; additionally prevents the result from being written to the cache. Any other value is ignored. | [optional]  |
 | **pragma** | **string** | HTTP/1.0 alias for &#x60;Cache-Control: no-cache&#x60;. Behaves identically when set to &#x60;no-cache&#x60;; ignored otherwise. | [optional]  |
 
 ### Return type
 
-[**ClientBatchVerifyApiKeysResponse**](ClientBatchVerifyApiKeysResponse.md)
+[**ClientBatchVerifyApiKeysResponse**](../models/ClientBatchVerifyApiKeysResponse.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -101,12 +171,45 @@ Verifies multiple credentials in a single request. Efficiently verifies up to 10
 
 <a id="admindeleteimportedapikey"></a>
 # **AdminDeleteImportedApiKey**
-> void AdminDeleteImportedApiKey (string keyId)
+> Task&lt;IAdminDeleteImportedApiKeyApiResponse&gt; AdminDeleteImportedApiKeyAsync(string keyId, System.Threading.CancellationToken cancellationToken = default)
 
 Delete Imported API Key
 
 Permanently deletes an imported key (hard delete). The key is removed from the database. Use AdminRevokeImportedApiKey for soft deletion (recommended).  ```http DELETE /v2alpha1/admin/importedApiKeys/{key_id} ```
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class AdminDeleteImportedApiKeyExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IApiKeysApi>();
+            string keyId = default!; // SHA512/256 hash of the imported key (REQUIRED)
+            await api.AdminDeleteImportedApiKeyAsync(keyId);
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -120,7 +223,7 @@ void (empty response body)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -138,26 +241,60 @@ void (empty response body)
 
 <a id="adminderivetoken"></a>
 # **AdminDeriveToken**
-> ClientDeriveTokenResponse AdminDeriveToken (ClientDeriveTokenRequest clientDeriveTokenRequest)
+> Task&lt;IAdminDeriveTokenApiResponse&gt; AdminDeriveTokenAsync(ClientDeriveTokenRequest clientDeriveTokenRequest, System.Threading.CancellationToken cancellationToken = default)
 
 Derive Token
 
 Mints a short-lived JWT or Macaroon token from an API key. Works with both issued and imported keys. The derived token inherits the permissions of the parent API key.  ```http POST /v2alpha1/admin/apiKeys:derive {   \"credential\": \"eyJhbGciOiJFZERTQSI...\",   \"ttl\": \"1h\" } ```
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class AdminDeriveTokenExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IApiKeysApi>();
+            ClientDeriveTokenRequest clientDeriveTokenRequest = default!; // 
+            var response = await api.AdminDeriveTokenAsync(clientDeriveTokenRequest);
+            ClientDeriveTokenResponse? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **clientDeriveTokenRequest** | [**ClientDeriveTokenRequest**](ClientDeriveTokenRequest.md) |  |  |
+| **clientDeriveTokenRequest** | [**ClientDeriveTokenRequest**](../models/ClientDeriveTokenRequest.md) |  |  |
 
 ### Return type
 
-[**ClientDeriveTokenResponse**](ClientDeriveTokenResponse.md)
+[**ClientDeriveTokenResponse**](../models/ClientDeriveTokenResponse.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -175,12 +312,46 @@ Mints a short-lived JWT or Macaroon token from an API key. Works with both issue
 
 <a id="admingetimportedapikey"></a>
 # **AdminGetImportedApiKey**
-> ClientImportedApiKey AdminGetImportedApiKey (string keyId)
+> Task&lt;IAdminGetImportedApiKeyApiResponse&gt; AdminGetImportedApiKeyAsync(string keyId, System.Threading.CancellationToken cancellationToken = default)
 
 Get Imported API Key
 
 Retrieves details about a specific imported key. Returns metadata about the imported key. The original raw key is never returned.  ```http GET /v2alpha1/admin/importedApiKeys/{key_id} ```
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class AdminGetImportedApiKeyExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IApiKeysApi>();
+            string keyId = default!; // SHA512/256 hash of the imported key (REQUIRED)
+            var response = await api.AdminGetImportedApiKeyAsync(keyId);
+            ClientImportedApiKey? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -190,11 +361,11 @@ Retrieves details about a specific imported key. Returns metadata about the impo
 
 ### Return type
 
-[**ClientImportedApiKey**](ClientImportedApiKey.md)
+[**ClientImportedApiKey**](../models/ClientImportedApiKey.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -212,12 +383,46 @@ Retrieves details about a specific imported key. Returns metadata about the impo
 
 <a id="admingetissuedapikey"></a>
 # **AdminGetIssuedApiKey**
-> ClientIssuedApiKey AdminGetIssuedApiKey (string keyId)
+> Task&lt;IAdminGetIssuedApiKeyApiResponse&gt; AdminGetIssuedApiKeyAsync(string keyId, System.Threading.CancellationToken cancellationToken = default)
 
 Get Issued API Key
 
 Retrieves details about a specific issued API key including its status, scopes, expiration, and usage statistics. The secret is never returned.  ```http GET /v2alpha1/admin/issuedApiKeys/01HQZX9VYQKJB8XQZQXQZQXQXQ ```
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class AdminGetIssuedApiKeyExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IApiKeysApi>();
+            string keyId = default!; // Identifier of the API key resource.
+            var response = await api.AdminGetIssuedApiKeyAsync(keyId);
+            ClientIssuedApiKey? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -227,11 +432,11 @@ Retrieves details about a specific issued API key including its status, scopes, 
 
 ### Return type
 
-[**ClientIssuedApiKey**](ClientIssuedApiKey.md)
+[**ClientIssuedApiKey**](../models/ClientIssuedApiKey.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -249,26 +454,60 @@ Retrieves details about a specific issued API key including its status, scopes, 
 
 <a id="adminimportapikey"></a>
 # **AdminImportApiKey**
-> ClientImportedApiKey AdminImportApiKey (ClientImportApiKeyRequest clientImportApiKeyRequest)
+> Task&lt;IAdminImportApiKeyApiResponse&gt; AdminImportApiKeyAsync(ClientImportApiKeyRequest clientImportApiKeyRequest, System.Threading.CancellationToken cancellationToken = default)
 
 Import API Key
 
 Imports an external API key into the system. Allows importing keys from legacy systems or external providers. The raw key is hashed and stored securely (HMAC). Imported keys support token derivation (JWT/Macaroon) like issued keys.  ```http POST /v2alpha1/admin/importedApiKeys {   \"raw_key\": \"imported-key-EXAMPLE-not-a-real-secret\",   \"name\": \"Example imported key\",   \"actor_id\": \"user_123\" } ```
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class AdminImportApiKeyExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IApiKeysApi>();
+            ClientImportApiKeyRequest clientImportApiKeyRequest = default!; // Example:   {     \"raw_key\": \"imported-key-EXAMPLE-not-a-real-secret\",     \"name\": \"Example imported key\",     \"actor_id\": \"payment-processor\",     \"scopes\": [\"read\", \"write\"],     \"ttl\": \"8760h\",  // 1 year (also accepts: 31536000s)     \"metadata\": {\"source\": \"example-provider\", \"environment\": \"staging\"}   }
+            var response = await api.AdminImportApiKeyAsync(clientImportApiKeyRequest);
+            ClientImportedApiKey? model = response.Created();
+        }
+    }
+}
+```
 
 ### Parameters
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **clientImportApiKeyRequest** | [**ClientImportApiKeyRequest**](ClientImportApiKeyRequest.md) | Example:   {     \&quot;raw_key\&quot;: \&quot;imported-key-EXAMPLE-not-a-real-secret\&quot;,     \&quot;name\&quot;: \&quot;Example imported key\&quot;,     \&quot;actor_id\&quot;: \&quot;payment-processor\&quot;,     \&quot;scopes\&quot;: [\&quot;read\&quot;, \&quot;write\&quot;],     \&quot;ttl\&quot;: \&quot;8760h\&quot;,  // 1 year (also accepts: 31536000s)     \&quot;metadata\&quot;: {\&quot;source\&quot;: \&quot;example-provider\&quot;, \&quot;environment\&quot;: \&quot;staging\&quot;}   } |  |
+| **clientImportApiKeyRequest** | [**ClientImportApiKeyRequest**](../models/ClientImportApiKeyRequest.md) | Example:   {     \&quot;raw_key\&quot;: \&quot;imported-key-EXAMPLE-not-a-real-secret\&quot;,     \&quot;name\&quot;: \&quot;Example imported key\&quot;,     \&quot;actor_id\&quot;: \&quot;payment-processor\&quot;,     \&quot;scopes\&quot;: [\&quot;read\&quot;, \&quot;write\&quot;],     \&quot;ttl\&quot;: \&quot;8760h\&quot;,  // 1 year (also accepts: 31536000s)     \&quot;metadata\&quot;: {\&quot;source\&quot;: \&quot;example-provider\&quot;, \&quot;environment\&quot;: \&quot;staging\&quot;}   } |  |
 
 ### Return type
 
-[**ClientImportedApiKey**](ClientImportedApiKey.md)
+[**ClientImportedApiKey**](../models/ClientImportedApiKey.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -286,26 +525,60 @@ Imports an external API key into the system. Allows importing keys from legacy s
 
 <a id="adminissueapikey"></a>
 # **AdminIssueApiKey**
-> ClientIssueApiKeyResponse AdminIssueApiKey (ClientIssueApiKeyRequest clientIssueApiKeyRequest)
+> Task&lt;IAdminIssueApiKeyApiResponse&gt; AdminIssueApiKeyAsync(ClientIssueApiKeyRequest clientIssueApiKeyRequest, System.Threading.CancellationToken cancellationToken = default)
 
 Issue API Key
 
 Creates a new API key for a given actor. The secret is returned only once in the response and cannot be retrieved later. Keys can be scoped with specific permissions and have optional expiration.  ```http POST /v2alpha1/admin/issuedApiKeys {   \"name\": \"production-service\",   \"actor_id\": \"user_123\",   \"scopes\": [\"read\", \"write\"],   \"ttl\": \"8760h\" } ```
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class AdminIssueApiKeyExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IApiKeysApi>();
+            ClientIssueApiKeyRequest clientIssueApiKeyRequest = default!; // 
+            var response = await api.AdminIssueApiKeyAsync(clientIssueApiKeyRequest);
+            ClientIssueApiKeyResponse? model = response.Created();
+        }
+    }
+}
+```
 
 ### Parameters
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **clientIssueApiKeyRequest** | [**ClientIssueApiKeyRequest**](ClientIssueApiKeyRequest.md) |  |  |
+| **clientIssueApiKeyRequest** | [**ClientIssueApiKeyRequest**](../models/ClientIssueApiKeyRequest.md) |  |  |
 
 ### Return type
 
-[**ClientIssueApiKeyResponse**](ClientIssueApiKeyResponse.md)
+[**ClientIssueApiKeyResponse**](../models/ClientIssueApiKeyResponse.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -323,12 +596,48 @@ Creates a new API key for a given actor. The secret is returned only once in the
 
 <a id="adminlistimportedapikeys"></a>
 # **AdminListImportedApiKeys**
-> ClientListImportedApiKeysResponse AdminListImportedApiKeys (int pageSize = null, string pageToken = null, string filter = null)
+> Task&lt;IAdminListImportedApiKeysApiResponse&gt; AdminListImportedApiKeysAsync(Option<int> pageSize = default, Option<string> pageToken = default, Option<string> filter = default, System.Threading.CancellationToken cancellationToken = default)
 
 List Imported API Keys
 
 Lists all imported keys with filtering. Returns imported keys only (not issued keys). Supports pagination and AIP-160 filter expressions.  ```http GET /v2alpha1/admin/importedApiKeys?page_size=50&filter=status%3DKEY_STATUS_ACTIVE ```
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class AdminListImportedApiKeysExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IApiKeysApi>();
+            Option<int> pageSize = default!; // Number of items per page (default: 50, max: 1000) (optional)
+            Option<string> pageToken = default!; // Cursor token for pagination (OPTIONAL) (optional)
+            Option<string> filter = default!; // filter is an AIP-160 expression. Indexed fields (efficient at any scale):   actor_id, status. Other fields are not indexed and may be rejected. Examples:   actor_id=\"user_123\"   status=KEY_STATUS_ACTIVE   actor_id=\"user_123\" AND status=KEY_STATUS_ACTIVE (optional)
+            var response = await api.AdminListImportedApiKeysAsync(pageSize, pageToken, filter);
+            ClientListImportedApiKeysResponse? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -340,11 +649,11 @@ Lists all imported keys with filtering. Returns imported keys only (not issued k
 
 ### Return type
 
-[**ClientListImportedApiKeysResponse**](ClientListImportedApiKeysResponse.md)
+[**ClientListImportedApiKeysResponse**](../models/ClientListImportedApiKeysResponse.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -362,12 +671,48 @@ Lists all imported keys with filtering. Returns imported keys only (not issued k
 
 <a id="adminlistissuedapikeys"></a>
 # **AdminListIssuedApiKeys**
-> ClientListIssuedApiKeysResponse AdminListIssuedApiKeys (int pageSize = null, string pageToken = null, string filter = null)
+> Task&lt;IAdminListIssuedApiKeysApiResponse&gt; AdminListIssuedApiKeysAsync(Option<int> pageSize = default, Option<string> pageToken = default, Option<string> filter = default, System.Threading.CancellationToken cancellationToken = default)
 
 List Issued API Keys
 
 Lists issued API keys with optional filtering. Supports cursor-based pagination and AIP-160 filter expressions. Returns only issued (generated) API keys; use ListImportedApiKeys for imported keys.  ```http GET /v2alpha1/admin/issuedApiKeys?page_size=50&filter=actor_id%3D%22user_123%22 ```
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class AdminListIssuedApiKeysExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IApiKeysApi>();
+            Option<int> pageSize = default!; // Number of items per page (default: 50, max: 1000) (optional)
+            Option<string> pageToken = default!; // Cursor token for pagination (optional)
+            Option<string> filter = default!; // filter is an AIP-160 expression. Indexed fields (efficient at any scale):   actor_id, status. Other fields are not indexed and may be rejected. Examples:   actor_id=\"user_123\"   status=KEY_STATUS_ACTIVE   actor_id=\"user_123\" AND status=KEY_STATUS_ACTIVE (optional)
+            var response = await api.AdminListIssuedApiKeysAsync(pageSize, pageToken, filter);
+            ClientListIssuedApiKeysResponse? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -379,11 +724,11 @@ Lists issued API keys with optional filtering. Supports cursor-based pagination 
 
 ### Return type
 
-[**ClientListIssuedApiKeysResponse**](ClientListIssuedApiKeysResponse.md)
+[**ClientListIssuedApiKeysResponse**](../models/ClientListIssuedApiKeysResponse.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -401,19 +746,53 @@ Lists issued API keys with optional filtering. Supports cursor-based pagination 
 
 <a id="adminrevokeimportedapikey"></a>
 # **AdminRevokeImportedApiKey**
-> void AdminRevokeImportedApiKey (string keyId, ClientAdminRevokeImportedApiKeyBody clientAdminRevokeImportedApiKeyBody)
+> Task&lt;IAdminRevokeImportedApiKeyApiResponse&gt; AdminRevokeImportedApiKeyAsync(string keyId, ClientAdminRevokeImportedApiKeyBody clientAdminRevokeImportedApiKeyBody, System.Threading.CancellationToken cancellationToken = default)
 
 Revoke Imported API Key
 
 Immediately revokes an imported API key. Once revoked, the key can no longer be used for authentication. This operation is irreversible. Revoked keys are retained for audit purposes.  ```http POST /v2alpha1/admin/importedApiKeys/9a3f051b2c7e8d4f1a6b9c0e5f2d8a3b:revoke {   \"reason\": \"REVOCATION_REASON_KEY_COMPROMISE\" } ```
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class AdminRevokeImportedApiKeyExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IApiKeysApi>();
+            string keyId = default!; // SHA-512/256 hash of the imported key (REQUIRED)
+            ClientAdminRevokeImportedApiKeyBody clientAdminRevokeImportedApiKeyBody = default!; // 
+            await api.AdminRevokeImportedApiKeyAsync(keyId, clientAdminRevokeImportedApiKeyBody);
+        }
+    }
+}
+```
 
 ### Parameters
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
 | **keyId** | **string** | SHA-512/256 hash of the imported key (REQUIRED) |  |
-| **clientAdminRevokeImportedApiKeyBody** | [**ClientAdminRevokeImportedApiKeyBody**](ClientAdminRevokeImportedApiKeyBody.md) |  |  |
+| **clientAdminRevokeImportedApiKeyBody** | [**ClientAdminRevokeImportedApiKeyBody**](../models/ClientAdminRevokeImportedApiKeyBody.md) |  |  |
 
 ### Return type
 
@@ -421,7 +800,7 @@ void (empty response body)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -439,19 +818,53 @@ void (empty response body)
 
 <a id="adminrevokeissuedapikey"></a>
 # **AdminRevokeIssuedApiKey**
-> void AdminRevokeIssuedApiKey (string keyId, ClientAdminRevokeIssuedApiKeyBody clientAdminRevokeIssuedApiKeyBody)
+> Task&lt;IAdminRevokeIssuedApiKeyApiResponse&gt; AdminRevokeIssuedApiKeyAsync(string keyId, ClientAdminRevokeIssuedApiKeyBody clientAdminRevokeIssuedApiKeyBody, System.Threading.CancellationToken cancellationToken = default)
 
 Revoke Issued API Key
 
 Immediately revokes an issued API key. Once revoked, the key can no longer be used for authentication. This operation is irreversible. Revoked keys are retained for audit purposes.  ```http POST /v2alpha1/admin/issuedApiKeys/01HQZX9VYQKJB8XQZQXQZQXQXQ:revoke {   \"reason\": \"REVOCATION_REASON_KEY_COMPROMISE\" } ```
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class AdminRevokeIssuedApiKeyExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IApiKeysApi>();
+            string keyId = default!; // UUID of the issued key (REQUIRED)
+            ClientAdminRevokeIssuedApiKeyBody clientAdminRevokeIssuedApiKeyBody = default!; // 
+            await api.AdminRevokeIssuedApiKeyAsync(keyId, clientAdminRevokeIssuedApiKeyBody);
+        }
+    }
+}
+```
 
 ### Parameters
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
 | **keyId** | **string** | UUID of the issued key (REQUIRED) |  |
-| **clientAdminRevokeIssuedApiKeyBody** | [**ClientAdminRevokeIssuedApiKeyBody**](ClientAdminRevokeIssuedApiKeyBody.md) |  |  |
+| **clientAdminRevokeIssuedApiKeyBody** | [**ClientAdminRevokeIssuedApiKeyBody**](../models/ClientAdminRevokeIssuedApiKeyBody.md) |  |  |
 
 ### Return type
 
@@ -459,7 +872,7 @@ void (empty response body)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -477,27 +890,62 @@ void (empty response body)
 
 <a id="adminrotateissuedapikey"></a>
 # **AdminRotateIssuedApiKey**
-> ClientRotateIssuedApiKeyResponse AdminRotateIssuedApiKey (string keyId, ClientAdminRotateIssuedApiKeyBody clientAdminRotateIssuedApiKeyBody)
+> Task&lt;IAdminRotateIssuedApiKeyApiResponse&gt; AdminRotateIssuedApiKeyAsync(string keyId, ClientAdminRotateIssuedApiKeyBody clientAdminRotateIssuedApiKeyBody, System.Threading.CancellationToken cancellationToken = default)
 
 Rotate Issued API Key
 
 Generates a new secret for an issued API key. Creates a new API key with a new key_id and secret, and immediately revokes the old key. This is the recommended way to update scopes, metadata, or rotate credentials.  For zero-downtime rotation, use this workflow instead:   1. IssueApiKey with new credentials   2. Deploy new secret to all services   3. Verify new secret works everywhere   4. AdminRevokeIssuedApiKey to remove the old key  ```http POST /v2alpha1/admin/issuedApiKeys/01HQZX9VYQKJB8XQZQXQZQXQXQ:rotate {   \"scopes\": [\"read\"] } ```
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class AdminRotateIssuedApiKeyExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IApiKeysApi>();
+            string keyId = default!; // key_id is the ID of the existing API key to rotate
+            ClientAdminRotateIssuedApiKeyBody clientAdminRotateIssuedApiKeyBody = default!; // 
+            var response = await api.AdminRotateIssuedApiKeyAsync(keyId, clientAdminRotateIssuedApiKeyBody);
+            ClientRotateIssuedApiKeyResponse? model = response.Created();
+        }
+    }
+}
+```
 
 ### Parameters
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
 | **keyId** | **string** | key_id is the ID of the existing API key to rotate |  |
-| **clientAdminRotateIssuedApiKeyBody** | [**ClientAdminRotateIssuedApiKeyBody**](ClientAdminRotateIssuedApiKeyBody.md) |  |  |
+| **clientAdminRotateIssuedApiKeyBody** | [**ClientAdminRotateIssuedApiKeyBody**](../models/ClientAdminRotateIssuedApiKeyBody.md) |  |  |
 
 ### Return type
 
-[**ClientRotateIssuedApiKeyResponse**](ClientRotateIssuedApiKeyResponse.md)
+[**ClientRotateIssuedApiKeyResponse**](../models/ClientRotateIssuedApiKeyResponse.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -515,28 +963,64 @@ Generates a new secret for an issued API key. Creates a new API key with a new k
 
 <a id="adminupdateimportedapikey"></a>
 # **AdminUpdateImportedApiKey**
-> ClientImportedApiKey AdminUpdateImportedApiKey (string keyId, ClientAdminUpdateImportedApiKeyRequest clientAdminUpdateImportedApiKeyRequest, string updateMask = null)
+> Task&lt;IAdminUpdateImportedApiKeyApiResponse&gt; AdminUpdateImportedApiKeyAsync(string keyId, ClientAdminUpdateImportedApiKeyRequest clientAdminUpdateImportedApiKeyRequest, Option<string> updateMask = default, System.Threading.CancellationToken cancellationToken = default)
 
 Update Imported API Key
 
 Updates metadata, scopes, or rate limits of an imported key. Supports partial updates via the update_mask query parameter (AIP-134). Omitting update_mask is equivalent to a mask of every populated field in the body. To clear a field to its zero value, list it explicitly in update_mask and leave it unset (or empty) in the body.  ```http PATCH /v2alpha1/admin/importedApiKeys/{key_id}?update_mask=name {   \"imported_api_key\": {     \"key_id\": \"{key_id}\",     \"name\": \"New name\"   } } ```
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class AdminUpdateImportedApiKeyExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IApiKeysApi>();
+            string keyId = default!; // SHA-512/256 hash of credential
+            ClientAdminUpdateImportedApiKeyRequest clientAdminUpdateImportedApiKeyRequest = default!; // 
+            Option<string> updateMask = default!; // The list of fields to update. See AIP-134. (optional)
+            var response = await api.AdminUpdateImportedApiKeyAsync(keyId, clientAdminUpdateImportedApiKeyRequest, updateMask);
+            ClientImportedApiKey? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
 | **keyId** | **string** | SHA-512/256 hash of credential |  |
-| **clientAdminUpdateImportedApiKeyRequest** | [**ClientAdminUpdateImportedApiKeyRequest**](ClientAdminUpdateImportedApiKeyRequest.md) |  |  |
+| **clientAdminUpdateImportedApiKeyRequest** | [**ClientAdminUpdateImportedApiKeyRequest**](../models/ClientAdminUpdateImportedApiKeyRequest.md) |  |  |
 | **updateMask** | **string** | The list of fields to update. See AIP-134. | [optional]  |
 
 ### Return type
 
-[**ClientImportedApiKey**](ClientImportedApiKey.md)
+[**ClientImportedApiKey**](../models/ClientImportedApiKey.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -554,28 +1038,64 @@ Updates metadata, scopes, or rate limits of an imported key. Supports partial up
 
 <a id="adminupdateissuedapikey"></a>
 # **AdminUpdateIssuedApiKey**
-> ClientIssuedApiKey AdminUpdateIssuedApiKey (string keyId, ClientAdminUpdateIssuedApiKeyRequest clientAdminUpdateIssuedApiKeyRequest, string updateMask = null)
+> Task&lt;IAdminUpdateIssuedApiKeyApiResponse&gt; AdminUpdateIssuedApiKeyAsync(string keyId, ClientAdminUpdateIssuedApiKeyRequest clientAdminUpdateIssuedApiKeyRequest, Option<string> updateMask = default, System.Threading.CancellationToken cancellationToken = default)
 
 Update Issued API Key
 
 Updates metadata, scopes, or rate limits of an issued key without rotating the secret. Use RotateIssuedApiKey to change the secret.  Follows AIP-134: the request body is the IssuedApiKey resource itself, and the update_mask query parameter names the subset of fields to apply. Omitting update_mask is equivalent to a mask of every populated field in the body. To clear a field to its zero value, list it explicitly in update_mask and leave it unset (or empty) in the body.  ```http PATCH /v2alpha1/admin/issuedApiKeys/01HQZX9VYQKJB8XQZQXQZQXQXQ?update_mask=scopes {   \"issued_api_key\": {     \"key_id\": \"01HQZX9VYQKJB8XQZQXQZQXQXQ\",     \"scopes\": [\"read\"]   } } ```
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class AdminUpdateIssuedApiKeyExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IApiKeysApi>();
+            string keyId = default!; // Identifier of the API key resource.
+            ClientAdminUpdateIssuedApiKeyRequest clientAdminUpdateIssuedApiKeyRequest = default!; // 
+            Option<string> updateMask = default!; // The list of fields to update. See AIP-134. (optional)
+            var response = await api.AdminUpdateIssuedApiKeyAsync(keyId, clientAdminUpdateIssuedApiKeyRequest, updateMask);
+            ClientIssuedApiKey? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
 | **keyId** | **string** | Identifier of the API key resource. |  |
-| **clientAdminUpdateIssuedApiKeyRequest** | [**ClientAdminUpdateIssuedApiKeyRequest**](ClientAdminUpdateIssuedApiKeyRequest.md) |  |  |
+| **clientAdminUpdateIssuedApiKeyRequest** | [**ClientAdminUpdateIssuedApiKeyRequest**](../models/ClientAdminUpdateIssuedApiKeyRequest.md) |  |  |
 | **updateMask** | **string** | The list of fields to update. See AIP-134. | [optional]  |
 
 ### Return type
 
-[**ClientIssuedApiKey**](ClientIssuedApiKey.md)
+[**ClientIssuedApiKey**](../models/ClientIssuedApiKey.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -593,28 +1113,64 @@ Updates metadata, scopes, or rate limits of an issued key without rotating the s
 
 <a id="adminverifyapikey"></a>
 # **AdminVerifyApiKey**
-> ClientVerifyApiKeyResponse AdminVerifyApiKey (ClientVerifyApiKeyRequest clientVerifyApiKeyRequest, string cacheControl = null, string pragma = null)
+> Task&lt;IAdminVerifyApiKeyApiResponse&gt; AdminVerifyApiKeyAsync(ClientVerifyApiKeyRequest clientVerifyApiKeyRequest, Option<string> cacheControl = default, Option<string> pragma = default, System.Threading.CancellationToken cancellationToken = default)
 
 Verify API Key
 
 Verifies a single API key or derived token. Validates the credential's signature, expiration, and revocation status. Works with any credential type (issued keys, imported keys, JWT, macaroon). The verification result includes decoded claims and metadata — admin access only.  Cache Control (HTTP Headers):   - Cache-Control: no-cache  - Bypasses cache read, forces fresh DB lookup   - Cache-Control: no-store  - Bypasses cache read AND write (never cached)   - Pragma: no-cache         - Same as Cache-Control: no-cache (HTTP/1.0)  ```http POST /v2alpha1/admin/apiKeys:verify {   \"credential\": \"sk_live_abc123...\" } ```
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class AdminVerifyApiKeyExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IApiKeysApi>();
+            ClientVerifyApiKeyRequest clientVerifyApiKeyRequest = default!; // 
+            Option<string> cacheControl = default!; // Cache-directive controlling the verifier cache. `no-cache` forces a fresh database lookup (cache read is bypassed). `no-store` additionally prevents the result from being written to the cache. Any other value is ignored. (optional)
+            Option<string> pragma = default!; // HTTP/1.0 alias for `Cache-Control: no-cache`. Behaves identically when set to `no-cache`; ignored otherwise. (optional)
+            var response = await api.AdminVerifyApiKeyAsync(clientVerifyApiKeyRequest, cacheControl, pragma);
+            ClientVerifyApiKeyResponse? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **clientVerifyApiKeyRequest** | [**ClientVerifyApiKeyRequest**](ClientVerifyApiKeyRequest.md) |  |  |
+| **clientVerifyApiKeyRequest** | [**ClientVerifyApiKeyRequest**](../models/ClientVerifyApiKeyRequest.md) |  |  |
 | **cacheControl** | **string** | Cache-directive controlling the verifier cache. &#x60;no-cache&#x60; forces a fresh database lookup (cache read is bypassed). &#x60;no-store&#x60; additionally prevents the result from being written to the cache. Any other value is ignored. | [optional]  |
 | **pragma** | **string** | HTTP/1.0 alias for &#x60;Cache-Control: no-cache&#x60;. Behaves identically when set to &#x60;no-cache&#x60;; ignored otherwise. | [optional]  |
 
 ### Return type
 
-[**ClientVerifyApiKeyResponse**](ClientVerifyApiKeyResponse.md)
+[**ClientVerifyApiKeyResponse**](../models/ClientVerifyApiKeyResponse.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -632,18 +1188,49 @@ Verifies a single API key or derived token. Validates the credential's signature
 
 <a id="getjwks"></a>
 # **GetJwks**
-> ClientGetJWKSResponse GetJwks ()
+> Task&lt;IGetJwksApiResponse&gt; GetJwksAsync(System.Threading.CancellationToken cancellationToken = default)
 
 Get JWKS
 
 Returns the JSON Web Key Set for token verification. Provides the public keys needed to verify JWT tokens issued by this service. Keys are loaded from configuration (file://, https://, or base64:// URIs). Follows the JWKS standard (RFC 7517).  ```http GET /v2alpha1/derivedKeys/jwks.json ```
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class GetJwksExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IApiKeysApi>();
+            var response = await api.GetJwksAsync();
+            ClientGetJWKSResponse? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 This endpoint does not need any parameter.
 ### Return type
 
-[**ClientGetJWKSResponse**](ClientGetJWKSResponse.md)
+[**ClientGetJWKSResponse**](../models/ClientGetJWKSResponse.md)
 
 ### Authorization
 
@@ -665,18 +1252,50 @@ No authorization required
 
 <a id="revokeapikey"></a>
 # **RevokeApiKey**
-> Object RevokeApiKey (ClientSelfRevokeApiKeyRequest clientSelfRevokeApiKeyRequest)
+> Task&lt;IRevokeApiKeyApiResponse&gt; RevokeApiKeyAsync(ClientSelfRevokeApiKeyRequest clientSelfRevokeApiKeyRequest, System.Threading.CancellationToken cancellationToken = default)
 
 Revoke API Key (self-service)
 
 Proof-of-possession variant of revocation. The `Self*` prefix on the request/response messages disambiguates from the admin variants (`AdminRevokeIssuedApiKey` / `AdminRevokeImportedApiKey`).  Allows an API key holder to revoke their own key. The caller must provide the full API key secret as proof of possession. Supports issued API keys and imported keys. JWT and macaroon tokens cannot be self-revoked (they are stateless).  The PRIVILEGE_WITHDRAWN reason is not allowed for self-revocation (admin-only).  ```http POST /v2alpha1/apiKeys:selfRevoke {   \"credential\": \"sk_live_abc123...\",   \"reason\": \"REVOCATION_REASON_KEY_COMPROMISE\" } ```
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class RevokeApiKeyExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IApiKeysApi>();
+            ClientSelfRevokeApiKeyRequest clientSelfRevokeApiKeyRequest = default!; // SelfRevokeApiKeyRequest allows an API key holder to revoke their own key by providing the full key secret as proof of possession.
+            var response = await api.RevokeApiKeyAsync(clientSelfRevokeApiKeyRequest);
+            Object? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **clientSelfRevokeApiKeyRequest** | [**ClientSelfRevokeApiKeyRequest**](ClientSelfRevokeApiKeyRequest.md) | SelfRevokeApiKeyRequest allows an API key holder to revoke their own key by providing the full key secret as proof of possession. |  |
+| **clientSelfRevokeApiKeyRequest** | [**ClientSelfRevokeApiKeyRequest**](../models/ClientSelfRevokeApiKeyRequest.md) | SelfRevokeApiKeyRequest allows an API key holder to revoke their own key by providing the full key secret as proof of possession. |  |
 
 ### Return type
 

--- a/clients/client/dotnet/docs/apis/CourierApi.md
+++ b/clients/client/dotnet/docs/apis/CourierApi.md
@@ -9,12 +9,46 @@ All URIs are relative to *https://playground.projects.oryapis.com*
 
 <a id="getcouriermessage"></a>
 # **GetCourierMessage**
-> ClientMessage GetCourierMessage (string id)
+> Task&lt;IGetCourierMessageApiResponse&gt; GetCourierMessageAsync(string id, System.Threading.CancellationToken cancellationToken = default)
 
 Get a Message
 
 Gets a specific messages by the given ID.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class GetCourierMessageExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<ICourierApi>();
+            string id = default!; // MessageID is the ID of the message.
+            var response = await api.GetCourierMessageAsync(id);
+            ClientMessage? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -24,11 +58,11 @@ Gets a specific messages by the given ID.
 
 ### Return type
 
-[**ClientMessage**](ClientMessage.md)
+[**ClientMessage**](../models/ClientMessage.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -47,12 +81,49 @@ Gets a specific messages by the given ID.
 
 <a id="listcouriermessages"></a>
 # **ListCourierMessages**
-> List&lt;ClientMessage&gt; ListCourierMessages (long pageSize = null, string pageToken = null, ClientCourierMessageStatus status = null, string recipient = null)
+> Task&lt;IListCourierMessagesApiResponse&gt; ListCourierMessagesAsync(Option<long> pageSize = default, Option<string> pageToken = default, Option<ClientCourierMessageStatus> status = default, Option<string> recipient = default, System.Threading.CancellationToken cancellationToken = default)
 
 List Messages
 
 Lists all messages by given status and recipient.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class ListCourierMessagesExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<ICourierApi>();
+            Option<long> pageSize = default!; // Items per Page  This is the number of items per page to return. For details on pagination please head over to the [pagination documentation](https://www.ory.com/docs/ecosystem/api-design#pagination). (optional)
+            Option<string> pageToken = default!; // Next Page Token  The next page token. For details on pagination please head over to the [pagination documentation](https://www.ory.com/docs/ecosystem/api-design#pagination). (optional)
+            Option<ClientCourierMessageStatus> status = default!; // Status filters out messages based on status. If no value is provided, it doesn't take effect on filter. (optional)
+            Option<string> recipient = default!; // Recipient filters out messages based on recipient. If no value is provided, it doesn't take effect on filter. (optional)
+            var response = await api.ListCourierMessagesAsync(pageSize, pageToken, status, recipient);
+            List<ClientMessage>? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -65,11 +136,11 @@ Lists all messages by given status and recipient.
 
 ### Return type
 
-[**List&lt;ClientMessage&gt;**](ClientMessage.md)
+[**List&lt;ClientMessage&gt;**](../models/ClientMessage.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 

--- a/clients/client/dotnet/docs/apis/ElementsApi.md
+++ b/clients/client/dotnet/docs/apis/ElementsApi.md
@@ -8,18 +8,49 @@ All URIs are relative to *https://playground.projects.oryapis.com*
 
 <a id="getconfiguration"></a>
 # **GetConfiguration**
-> ClientElementsConfiguration GetConfiguration ()
+> Task&lt;IGetConfigurationApiResponse&gt; GetConfigurationAsync(System.Threading.CancellationToken cancellationToken = default)
 
 Get Ory Elements configuration
 
 Returns a subset of the project's configuration for the given host. The response only contains non-sensitive data that is used to customize the behavior of Ory Elements.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class GetConfigurationExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IElementsApi>();
+            var response = await api.GetConfigurationAsync();
+            ClientElementsConfiguration? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 This endpoint does not need any parameter.
 ### Return type
 
-[**ClientElementsConfiguration**](ClientElementsConfiguration.md)
+[**ClientElementsConfiguration**](../models/ClientElementsConfiguration.md)
 
 ### Authorization
 

--- a/clients/client/dotnet/docs/apis/EventsApi.md
+++ b/clients/client/dotnet/docs/apis/EventsApi.md
@@ -11,25 +11,60 @@ All URIs are relative to *https://playground.projects.oryapis.com*
 
 <a id="createeventstream"></a>
 # **CreateEventStream**
-> ClientEventStream CreateEventStream (string projectId, ClientCreateEventStreamBody clientCreateEventStreamBody)
+> Task&lt;ICreateEventStreamApiResponse&gt; CreateEventStreamAsync(string projectId, ClientCreateEventStreamBody clientCreateEventStreamBody, System.Threading.CancellationToken cancellationToken = default)
 
 Create an event stream for your project.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class CreateEventStreamExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IEventsApi>();
+            string projectId = default!; // Project ID  The project's ID.
+            ClientCreateEventStreamBody clientCreateEventStreamBody = default!; // 
+            var response = await api.CreateEventStreamAsync(projectId, clientCreateEventStreamBody);
+            ClientEventStream? model = response.Created();
+        }
+    }
+}
+```
 
 ### Parameters
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
 | **projectId** | **string** | Project ID  The project&#39;s ID. |  |
-| **clientCreateEventStreamBody** | [**ClientCreateEventStreamBody**](ClientCreateEventStreamBody.md) |  |  |
+| **clientCreateEventStreamBody** | [**ClientCreateEventStreamBody**](../models/ClientCreateEventStreamBody.md) |  |  |
 
 ### Return type
 
-[**ClientEventStream**](ClientEventStream.md)
+[**ClientEventStream**](../models/ClientEventStream.md)
 
 ### Authorization
 
-[oryWorkspaceApiKey](../README.md#oryWorkspaceApiKey)
+[oryWorkspaceApiKey](../../README.md#oryWorkspaceApiKey)
 
 ### HTTP request headers
 
@@ -50,12 +85,46 @@ Create an event stream for your project.
 
 <a id="deleteeventstream"></a>
 # **DeleteEventStream**
-> void DeleteEventStream (string projectId, string eventStreamId)
+> Task&lt;IDeleteEventStreamApiResponse&gt; DeleteEventStreamAsync(string projectId, string eventStreamId, System.Threading.CancellationToken cancellationToken = default)
 
 Remove an event stream from a project
 
 Remove an event stream from a project.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class DeleteEventStreamExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IEventsApi>();
+            string projectId = default!; // Project ID  The project's ID.
+            string eventStreamId = default!; // Event Stream ID  The ID of the event stream to be deleted, as returned when created.
+            await api.DeleteEventStreamAsync(projectId, eventStreamId);
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -70,7 +139,7 @@ void (empty response body)
 
 ### Authorization
 
-[oryWorkspaceApiKey](../README.md#oryWorkspaceApiKey)
+[oryWorkspaceApiKey](../../README.md#oryWorkspaceApiKey)
 
 ### HTTP request headers
 
@@ -91,10 +160,44 @@ void (empty response body)
 
 <a id="listeventstreams"></a>
 # **ListEventStreams**
-> ClientListEventStreams ListEventStreams (string projectId)
+> Task&lt;IListEventStreamsApiResponse&gt; ListEventStreamsAsync(string projectId, System.Threading.CancellationToken cancellationToken = default)
 
 List all event streams for the project. This endpoint is not paginated.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class ListEventStreamsExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IEventsApi>();
+            string projectId = default!; // Project ID  The project's ID.
+            var response = await api.ListEventStreamsAsync(projectId);
+            ClientListEventStreams? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -104,11 +207,11 @@ List all event streams for the project. This endpoint is not paginated.
 
 ### Return type
 
-[**ClientListEventStreams**](ClientListEventStreams.md)
+[**ClientListEventStreams**](../models/ClientListEventStreams.md)
 
 ### Authorization
 
-[oryWorkspaceApiKey](../README.md#oryWorkspaceApiKey)
+[oryWorkspaceApiKey](../../README.md#oryWorkspaceApiKey)
 
 ### HTTP request headers
 
@@ -128,10 +231,46 @@ List all event streams for the project. This endpoint is not paginated.
 
 <a id="seteventstream"></a>
 # **SetEventStream**
-> ClientEventStream SetEventStream (string projectId, string eventStreamId, ClientSetEventStreamBody clientSetEventStreamBody = null)
+> Task&lt;ISetEventStreamApiResponse&gt; SetEventStreamAsync(string projectId, string eventStreamId, Option<ClientSetEventStreamBody> clientSetEventStreamBody = default, System.Threading.CancellationToken cancellationToken = default)
 
 Update an event stream for a project.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class SetEventStreamExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IEventsApi>();
+            string projectId = default!; // Project ID  The project's ID.
+            string eventStreamId = default!; // Event Stream ID  The event stream's ID.
+            Option<ClientSetEventStreamBody> clientSetEventStreamBody = default!; //  (optional)
+            var response = await api.SetEventStreamAsync(projectId, eventStreamId, clientSetEventStreamBody);
+            ClientEventStream? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -139,15 +278,15 @@ Update an event stream for a project.
 |------|------|-------------|-------|
 | **projectId** | **string** | Project ID  The project&#39;s ID. |  |
 | **eventStreamId** | **string** | Event Stream ID  The event stream&#39;s ID. |  |
-| **clientSetEventStreamBody** | [**ClientSetEventStreamBody**](ClientSetEventStreamBody.md) |  | [optional]  |
+| **clientSetEventStreamBody** | [**ClientSetEventStreamBody**](../models/ClientSetEventStreamBody.md) |  | [optional]  |
 
 ### Return type
 
-[**ClientEventStream**](ClientEventStream.md)
+[**ClientEventStream**](../models/ClientEventStream.md)
 
 ### Authorization
 
-[oryWorkspaceApiKey](../README.md#oryWorkspaceApiKey)
+[oryWorkspaceApiKey](../../README.md#oryWorkspaceApiKey)
 
 ### HTTP request headers
 

--- a/clients/client/dotnet/docs/apis/FrontendApi.md
+++ b/clients/client/dotnet/docs/apis/FrontendApi.md
@@ -41,12 +41,51 @@ All URIs are relative to *https://playground.projects.oryapis.com*
 
 <a id="createbrowserloginflow"></a>
 # **CreateBrowserLoginFlow**
-> ClientLoginFlow CreateBrowserLoginFlow (bool refresh = null, string aal = null, string returnTo = null, string cookie = null, string loginChallenge = null, string organization = null, string via = null, string identitySchema = null)
+> Task&lt;ICreateBrowserLoginFlowApiResponse&gt; CreateBrowserLoginFlowAsync(Option<bool> refresh = default, Option<string> aal = default, Option<string> returnTo = default, Option<string> cookie = default, Option<string> loginChallenge = default, Option<string> organization = default, Option<string> via = default, Option<string> identitySchema = default, System.Threading.CancellationToken cancellationToken = default)
 
 Create Login Flow for Browsers
 
 This endpoint initializes a browser-based user login flow. This endpoint will set the appropriate cookies and anti-CSRF measures required for browser-based flows.  If this endpoint is opened as a link in the browser, it will be redirected to `selfservice.flows.login.ui_url` with the flow ID set as the query parameter `?flow=`. If a valid user session exists already, the browser will be redirected to `urls.default_redirect_url` unless the query parameter `?refresh=true` was set.  If this endpoint is called via an AJAX request, the response contains the flow without a redirect. In the case of an error, the `error.id` of the JSON response body can be one of:  `session_already_available`: The user is already signed in. `session_aal1_required`: Multi-factor auth (e.g. 2fa) was requested but the user has no session yet. `security_csrf_violation`: Unable to fetch the flow because a CSRF violation occurred. `security_identity_mismatch`: The requested `?return_to` address is not allowed to be used. Adjust this in the configuration!  The optional query parameter login_challenge is set when using Kratos with Hydra in an OAuth2 flow. See the oauth2_provider.url configuration option.  This endpoint is NOT INTENDED for clients that do not have a browser (Chrome, Firefox, ...) as cookies are needed.  More information can be found at [Ory Kratos User Login](https://www.ory.com/docs/kratos/self-service/flows/user-login) and [User Registration Documentation](https://www.ory.com/docs/kratos/self-service/flows/user-registration).
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class CreateBrowserLoginFlowExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IFrontendApi>();
+            Option<bool> refresh = default!; // Refresh a login session  If set to true, this will refresh an existing login session by asking the user to sign in again. This will reset the authenticated_at time of the session. (optional)
+            Option<string> aal = default!; // Request a Specific AuthenticationMethod Assurance Level  Use this parameter to upgrade an existing session's authenticator assurance level (AAL). This allows you to ask for multi-factor authentication. When an identity sign in using e.g. username+password, the AAL is 1. If you wish to \"upgrade\" the session's security by asking the user to perform TOTP / WebAuth/ ... you would set this to \"aal2\". (optional)
+            Option<string> returnTo = default!; // The URL to return the browser to after the flow was completed. (optional)
+            Option<string> cookie = default!; // HTTP Cookies  When using the SDK in a browser app, on the server side you must include the HTTP Cookie Header sent by the client to your server here. This ensures that CSRF and session cookies are respected. (optional)
+            Option<string> loginChallenge = default!; // An optional Hydra login challenge. If present, Kratos will cooperate with Ory Hydra to act as an OAuth2 identity provider.  The value for this parameter comes from `login_challenge` URL Query parameter sent to your application (e.g. `/login?login_challenge=abcde`). (optional)
+            Option<string> organization = default!; // An optional organization ID that should be used for logging this user in. This parameter is only effective in the Ory Network. (optional)
+            Option<string> via = default!; // Via should contain the identity's credential the code should be sent to. Only relevant in aal2 flows.  DEPRECATED: This field is deprecated. Please remove it from your requests. The user will now see a choice of MFA credentials to choose from to perform the second factor instead. (optional)
+            Option<string> identitySchema = default!; // An optional identity schema to use for the login flow. (optional)
+            var response = await api.CreateBrowserLoginFlowAsync(refresh, aal, returnTo, cookie, loginChallenge, organization, via, identitySchema);
+            ClientLoginFlow? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -63,7 +102,7 @@ This endpoint initializes a browser-based user login flow. This endpoint will se
 
 ### Return type
 
-[**ClientLoginFlow**](ClientLoginFlow.md)
+[**ClientLoginFlow**](../models/ClientLoginFlow.md)
 
 ### Authorization
 
@@ -87,12 +126,45 @@ No authorization required
 
 <a id="createbrowserlogoutflow"></a>
 # **CreateBrowserLogoutFlow**
-> ClientLogoutFlow CreateBrowserLogoutFlow (string cookie = null, string returnTo = null)
+> Task&lt;ICreateBrowserLogoutFlowApiResponse&gt; CreateBrowserLogoutFlowAsync(Option<string> cookie = default, Option<string> returnTo = default, System.Threading.CancellationToken cancellationToken = default)
 
 Create a Logout URL for Browsers
 
 This endpoint initializes a browser-based user logout flow and a URL which can be used to log out the user.  This endpoint is NOT INTENDED for API clients and only works with browsers (Chrome, Firefox, ...). For API clients you can call the `/self-service/logout/api` URL directly with the Ory Session Token.  The URL is only valid for the currently signed in user. If no user is signed in, this endpoint returns a 401 error.  When calling this endpoint from a backend, please ensure to properly forward the HTTP cookies.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class CreateBrowserLogoutFlowExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IFrontendApi>();
+            Option<string> cookie = default!; // HTTP Cookies  If you call this endpoint from a backend, please include the original Cookie header in the request. (optional)
+            Option<string> returnTo = default!; // Return to URL  The URL to which the browser should be redirected to after the logout has been performed. (optional)
+            var response = await api.CreateBrowserLogoutFlowAsync(cookie, returnTo);
+            ClientLogoutFlow? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -103,7 +175,7 @@ This endpoint initializes a browser-based user logout flow and a URL which can b
 
 ### Return type
 
-[**ClientLogoutFlow**](ClientLogoutFlow.md)
+[**ClientLogoutFlow**](../models/ClientLogoutFlow.md)
 
 ### Authorization
 
@@ -127,12 +199,45 @@ No authorization required
 
 <a id="createbrowserrecoveryflow"></a>
 # **CreateBrowserRecoveryFlow**
-> ClientRecoveryFlow CreateBrowserRecoveryFlow (string returnTo = null, string skipSettings = null)
+> Task&lt;ICreateBrowserRecoveryFlowApiResponse&gt; CreateBrowserRecoveryFlowAsync(Option<string> returnTo = default, Option<string> skipSettings = default, System.Threading.CancellationToken cancellationToken = default)
 
 Create Recovery Flow for Browsers
 
 This endpoint initializes a browser-based account recovery flow. Once initialized, the browser will be redirected to `selfservice.flows.recovery.ui_url` with the flow ID set as the query parameter `?flow=`. If a valid user session exists, the browser is returned to the configured return URL.  If this endpoint is called via an AJAX request, the response contains the recovery flow without any redirects or a 400 bad request error if the user is already authenticated.  This endpoint is NOT INTENDED for clients that do not have a browser (Chrome, Firefox, ...) as cookies are needed.  More information can be found at [Ory Kratos Account Recovery Documentation](../self-service/flows/account-recovery).
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class CreateBrowserRecoveryFlowExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IFrontendApi>();
+            Option<string> returnTo = default!; // The URL to return the browser to after the flow was completed. (optional)
+            Option<string> skipSettings = default!; // Skip redirection to the settings UI after the recovery flow was completed. Instead, the user will be redirected to the URL specified in `return_to` query parameter or the default return URL if `return_to` is not set. (optional)
+            var response = await api.CreateBrowserRecoveryFlowAsync(returnTo, skipSettings);
+            ClientRecoveryFlow? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -143,7 +248,7 @@ This endpoint initializes a browser-based account recovery flow. Once initialize
 
 ### Return type
 
-[**ClientRecoveryFlow**](ClientRecoveryFlow.md)
+[**ClientRecoveryFlow**](../models/ClientRecoveryFlow.md)
 
 ### Authorization
 
@@ -167,12 +272,48 @@ No authorization required
 
 <a id="createbrowserregistrationflow"></a>
 # **CreateBrowserRegistrationFlow**
-> ClientRegistrationFlow CreateBrowserRegistrationFlow (string returnTo = null, string loginChallenge = null, string afterVerificationReturnTo = null, string organization = null, string identitySchema = null)
+> Task&lt;ICreateBrowserRegistrationFlowApiResponse&gt; CreateBrowserRegistrationFlowAsync(Option<string> returnTo = default, Option<string> loginChallenge = default, Option<string> afterVerificationReturnTo = default, Option<string> organization = default, Option<string> identitySchema = default, System.Threading.CancellationToken cancellationToken = default)
 
 Create Registration Flow for Browsers
 
 This endpoint initializes a browser-based user registration flow. This endpoint will set the appropriate cookies and anti-CSRF measures required for browser-based flows.  If this endpoint is opened as a link in the browser, it will be redirected to `selfservice.flows.registration.ui_url` with the flow ID set as the query parameter `?flow=`. If a valid user session exists already, the browser will be redirected to `urls.default_redirect_url`.  If this endpoint is called via an AJAX request, the response contains the flow without a redirect. In the case of an error, the `error.id` of the JSON response body can be one of:  `session_already_available`: The user is already signed in. `security_csrf_violation`: Unable to fetch the flow because a CSRF violation occurred. `security_identity_mismatch`: The requested `?return_to` address is not allowed to be used. Adjust this in the configuration!  If this endpoint is called via an AJAX request, the response contains the registration flow without a redirect.  This endpoint is NOT INTENDED for clients that do not have a browser (Chrome, Firefox, ...) as cookies are needed.  More information can be found at [Ory Kratos User Login](https://www.ory.com/docs/kratos/self-service/flows/user-login) and [User Registration Documentation](https://www.ory.com/docs/kratos/self-service/flows/user-registration).
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class CreateBrowserRegistrationFlowExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IFrontendApi>();
+            Option<string> returnTo = default!; // The URL to return the browser to after the flow was completed. (optional)
+            Option<string> loginChallenge = default!; // Ory OAuth 2.0 Login Challenge.  If set will cooperate with Ory OAuth2 and OpenID to act as an OAuth2 server / OpenID Provider.  The value for this parameter comes from `login_challenge` URL Query parameter sent to your application (e.g. `/registration?login_challenge=abcde`).  This feature is compatible with Ory Hydra when not running on the Ory Network. (optional)
+            Option<string> afterVerificationReturnTo = default!; // The URL to return the browser to after the verification flow was completed.  After the registration flow is completed, the user will be sent a verification email. Upon completing the verification flow, this URL will be used to override the default `selfservice.flows.verification.after.default_redirect_to` value. (optional)
+            Option<string> organization = default!; // An optional organization ID that should be used to register this user. This parameter is only effective in the Ory Network. (optional)
+            Option<string> identitySchema = default!; // An optional identity schema to use for the registration flow. (optional)
+            var response = await api.CreateBrowserRegistrationFlowAsync(returnTo, loginChallenge, afterVerificationReturnTo, organization, identitySchema);
+            ClientRegistrationFlow? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -186,7 +327,7 @@ This endpoint initializes a browser-based user registration flow. This endpoint 
 
 ### Return type
 
-[**ClientRegistrationFlow**](ClientRegistrationFlow.md)
+[**ClientRegistrationFlow**](../models/ClientRegistrationFlow.md)
 
 ### Authorization
 
@@ -209,12 +350,46 @@ No authorization required
 
 <a id="createbrowsersettingsflow"></a>
 # **CreateBrowserSettingsFlow**
-> ClientSettingsFlow CreateBrowserSettingsFlow (string returnTo = null, string cookie = null, string organization = null)
+> Task&lt;ICreateBrowserSettingsFlowApiResponse&gt; CreateBrowserSettingsFlowAsync(Option<string> returnTo = default, Option<string> cookie = default, Option<string> organization = default, System.Threading.CancellationToken cancellationToken = default)
 
 Create Settings Flow for Browsers
 
 This endpoint initializes a browser-based user settings flow. Once initialized, the browser will be redirected to `selfservice.flows.settings.ui_url` with the flow ID set as the query parameter `?flow=`. If no valid Ory Kratos Session Cookie is included in the request, a login flow will be initialized.  If this endpoint is opened as a link in the browser, it will be redirected to `selfservice.flows.settings.ui_url` with the flow ID set as the query parameter `?flow=`. If no valid user session was set, the browser will be redirected to the login endpoint.  If this endpoint is called via an AJAX request, the response contains the settings flow without any redirects or a 401 forbidden error if no valid session was set.  Depending on your configuration this endpoint might return a 403 error if the session has a lower Authenticator Assurance Level (AAL) than is possible for the identity. This can happen if the identity has password + webauthn credentials (which would result in AAL2) but the session has only AAL1. If this error occurs, ask the user to sign in with the second factor (happens automatically for server-side browser flows) or change the configuration.  If this endpoint is called via an AJAX request, the response contains the flow without a redirect. In the case of an error, the `error.id` of the JSON response body can be one of:  `security_csrf_violation`: Unable to fetch the flow because a CSRF violation occurred. `session_inactive`: No Ory Session was found - sign in a user first. `security_identity_mismatch`: The requested `?return_to` address is not allowed to be used. Adjust this in the configuration!  This endpoint is NOT INTENDED for clients that do not have a browser (Chrome, Firefox, ...) as cookies are needed.  More information can be found at [Ory Kratos User Settings & Profile Management Documentation](../self-service/flows/user-settings).
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class CreateBrowserSettingsFlowExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IFrontendApi>();
+            Option<string> returnTo = default!; // The URL to return the browser to after the flow was completed. (optional)
+            Option<string> cookie = default!; // HTTP Cookies  When using the SDK in a browser app, on the server side you must include the HTTP Cookie Header sent by the client to your server here. This ensures that CSRF and session cookies are respected. (optional)
+            Option<string> organization = default!; // An optional organization ID that scopes the settings flow to providers of that organization. This parameter is only effective in the Ory Network. (optional)
+            var response = await api.CreateBrowserSettingsFlowAsync(returnTo, cookie, organization);
+            ClientSettingsFlow? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -226,7 +401,7 @@ This endpoint initializes a browser-based user settings flow. Once initialized, 
 
 ### Return type
 
-[**ClientSettingsFlow**](ClientSettingsFlow.md)
+[**ClientSettingsFlow**](../models/ClientSettingsFlow.md)
 
 ### Authorization
 
@@ -252,12 +427,44 @@ No authorization required
 
 <a id="createbrowserverificationflow"></a>
 # **CreateBrowserVerificationFlow**
-> ClientVerificationFlow CreateBrowserVerificationFlow (string returnTo = null)
+> Task&lt;ICreateBrowserVerificationFlowApiResponse&gt; CreateBrowserVerificationFlowAsync(Option<string> returnTo = default, System.Threading.CancellationToken cancellationToken = default)
 
 Create Verification Flow for Browser Clients
 
 This endpoint initializes a browser-based account verification flow. Once initialized, the browser will be redirected to `selfservice.flows.verification.ui_url` with the flow ID set as the query parameter `?flow=`.  If this endpoint is called via an AJAX request, the response contains the recovery flow without any redirects.  This endpoint is NOT INTENDED for API clients and only works with browsers (Chrome, Firefox, ...).  More information can be found at [Ory Kratos Email and Phone Verification Documentation](https://www.ory.com/docs/kratos/self-service/flows/verify-email-account-activation).
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class CreateBrowserVerificationFlowExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IFrontendApi>();
+            Option<string> returnTo = default!; // The URL to return the browser to after the flow was completed. (optional)
+            var response = await api.CreateBrowserVerificationFlowAsync(returnTo);
+            ClientVerificationFlow? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -267,7 +474,7 @@ This endpoint initializes a browser-based account verification flow. Once initia
 
 ### Return type
 
-[**ClientVerificationFlow**](ClientVerificationFlow.md)
+[**ClientVerificationFlow**](../models/ClientVerificationFlow.md)
 
 ### Authorization
 
@@ -290,18 +497,49 @@ No authorization required
 
 <a id="createfedcmflow"></a>
 # **CreateFedcmFlow**
-> ClientCreateFedcmFlowResponse CreateFedcmFlow ()
+> Task&lt;ICreateFedcmFlowApiResponse&gt; CreateFedcmFlowAsync(System.Threading.CancellationToken cancellationToken = default)
 
 Get FedCM Parameters
 
 This endpoint returns a list of all available FedCM providers. It is only supported on the Ory Network.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class CreateFedcmFlowExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IFrontendApi>();
+            var response = await api.CreateFedcmFlowAsync();
+            ClientCreateFedcmFlowResponse? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 This endpoint does not need any parameter.
 ### Return type
 
-[**ClientCreateFedcmFlowResponse**](ClientCreateFedcmFlowResponse.md)
+[**ClientCreateFedcmFlowResponse**](../models/ClientCreateFedcmFlowResponse.md)
 
 ### Authorization
 
@@ -324,12 +562,51 @@ No authorization required
 
 <a id="createnativeloginflow"></a>
 # **CreateNativeLoginFlow**
-> ClientLoginFlow CreateNativeLoginFlow (bool refresh = null, string aal = null, string xSessionToken = null, bool returnSessionTokenExchangeCode = null, string returnTo = null, string organization = null, string via = null, string identitySchema = null)
+> Task&lt;ICreateNativeLoginFlowApiResponse&gt; CreateNativeLoginFlowAsync(Option<bool> refresh = default, Option<string> aal = default, Option<string> xSessionToken = default, Option<bool> returnSessionTokenExchangeCode = default, Option<string> returnTo = default, Option<string> organization = default, Option<string> via = default, Option<string> identitySchema = default, System.Threading.CancellationToken cancellationToken = default)
 
 Create Login Flow for Native Apps
 
 This endpoint initiates a login flow for native apps that do not use a browser, such as mobile devices, smart TVs, and so on.  If a valid provided session cookie or session token is provided, a 400 Bad Request error will be returned unless the URL query parameter `?refresh=true` is set.  To fetch an existing login flow call `/self-service/login/flows?flow=<flow_id>`.  You MUST NOT use this endpoint in client-side (Single Page Apps, ReactJS, AngularJS) nor server-side (Java Server Pages, NodeJS, PHP, Golang, ...) browser applications. Using this endpoint in these applications will make you vulnerable to a variety of CSRF attacks, including CSRF login attacks.  In the case of an error, the `error.id` of the JSON response body can be one of:  `session_already_available`: The user is already signed in. `session_aal1_required`: Multi-factor auth (e.g. 2fa) was requested but the user has no session yet. `security_csrf_violation`: Unable to fetch the flow because a CSRF violation occurred.  This endpoint MUST ONLY be used in scenarios such as native mobile apps (React Native, Objective C, Swift, Java, ...).  More information can be found at [Ory Kratos User Login](https://www.ory.com/docs/kratos/self-service/flows/user-login) and [User Registration Documentation](https://www.ory.com/docs/kratos/self-service/flows/user-registration).
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class CreateNativeLoginFlowExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IFrontendApi>();
+            Option<bool> refresh = default!; // Refresh a login session  If set to true, this will refresh an existing login session by asking the user to sign in again. This will reset the authenticated_at time of the session. (optional)
+            Option<string> aal = default!; // Request a Specific AuthenticationMethod Assurance Level  Use this parameter to upgrade an existing session's authenticator assurance level (AAL). This allows you to ask for multi-factor authentication. When an identity sign in using e.g. username+password, the AAL is 1. If you wish to \"upgrade\" the session's security by asking the user to perform TOTP / WebAuth/ ... you would set this to \"aal2\". (optional)
+            Option<string> xSessionToken = default!; // The Session Token of the Identity performing the settings flow. (optional)
+            Option<bool> returnSessionTokenExchangeCode = default!; // EnableSessionTokenExchangeCode requests the login flow to include a code that can be used to retrieve the session token after the login flow has been completed. (optional)
+            Option<string> returnTo = default!; // The URL to return the browser to after the flow was completed. (optional)
+            Option<string> organization = default!; // An optional organization ID that should be used for logging this user in. This parameter is only effective in the Ory Network. (optional)
+            Option<string> via = default!; // Via should contain the identity's credential the code should be sent to. Only relevant in aal2 flows.  DEPRECATED: This field is deprecated. Please remove it from your requests. The user will now see a choice of MFA credentials to choose from to perform the second factor instead. (optional)
+            Option<string> identitySchema = default!; // An optional identity schema to use for the login flow. (optional)
+            var response = await api.CreateNativeLoginFlowAsync(refresh, aal, xSessionToken, returnSessionTokenExchangeCode, returnTo, organization, via, identitySchema);
+            ClientLoginFlow? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -346,7 +623,7 @@ This endpoint initiates a login flow for native apps that do not use a browser, 
 
 ### Return type
 
-[**ClientLoginFlow**](ClientLoginFlow.md)
+[**ClientLoginFlow**](../models/ClientLoginFlow.md)
 
 ### Authorization
 
@@ -369,18 +646,49 @@ No authorization required
 
 <a id="createnativerecoveryflow"></a>
 # **CreateNativeRecoveryFlow**
-> ClientRecoveryFlow CreateNativeRecoveryFlow ()
+> Task&lt;ICreateNativeRecoveryFlowApiResponse&gt; CreateNativeRecoveryFlowAsync(System.Threading.CancellationToken cancellationToken = default)
 
 Create Recovery Flow for Native Apps
 
 This endpoint initiates a recovery flow for API clients such as mobile devices, smart TVs, and so on.  If a valid provided session cookie or session token is provided, a 400 Bad Request error.  On an existing recovery flow, use the `getRecoveryFlow` API endpoint.  You MUST NOT use this endpoint in client-side (Single Page Apps, ReactJS, AngularJS) nor server-side (Java Server Pages, NodeJS, PHP, Golang, ...) browser applications. Using this endpoint in these applications will make you vulnerable to a variety of CSRF attacks.  This endpoint MUST ONLY be used in scenarios such as native mobile apps (React Native, Objective C, Swift, Java, ...).  More information can be found at [Ory Kratos Account Recovery Documentation](../self-service/flows/account-recovery).
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class CreateNativeRecoveryFlowExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IFrontendApi>();
+            var response = await api.CreateNativeRecoveryFlowAsync();
+            ClientRecoveryFlow? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 This endpoint does not need any parameter.
 ### Return type
 
-[**ClientRecoveryFlow**](ClientRecoveryFlow.md)
+[**ClientRecoveryFlow**](../models/ClientRecoveryFlow.md)
 
 ### Authorization
 
@@ -403,12 +711,47 @@ No authorization required
 
 <a id="createnativeregistrationflow"></a>
 # **CreateNativeRegistrationFlow**
-> ClientRegistrationFlow CreateNativeRegistrationFlow (bool returnSessionTokenExchangeCode = null, string returnTo = null, string organization = null, string identitySchema = null)
+> Task&lt;ICreateNativeRegistrationFlowApiResponse&gt; CreateNativeRegistrationFlowAsync(Option<bool> returnSessionTokenExchangeCode = default, Option<string> returnTo = default, Option<string> organization = default, Option<string> identitySchema = default, System.Threading.CancellationToken cancellationToken = default)
 
 Create Registration Flow for Native Apps
 
 This endpoint initiates a registration flow for API clients such as mobile devices, smart TVs, and so on.  If a valid provided session cookie or session token is provided, a 400 Bad Request error will be returned unless the URL query parameter `?refresh=true` is set.  To fetch an existing registration flow call `/self-service/registration/flows?flow=<flow_id>`.  You MUST NOT use this endpoint in client-side (Single Page Apps, ReactJS, AngularJS) nor server-side (Java Server Pages, NodeJS, PHP, Golang, ...) browser applications. Using this endpoint in these applications will make you vulnerable to a variety of CSRF attacks.  In the case of an error, the `error.id` of the JSON response body can be one of:  `session_already_available`: The user is already signed in. `security_csrf_violation`: Unable to fetch the flow because a CSRF violation occurred.  This endpoint MUST ONLY be used in scenarios such as native mobile apps (React Native, Objective C, Swift, Java, ...).  More information can be found at [Ory Kratos User Login](https://www.ory.com/docs/kratos/self-service/flows/user-login) and [User Registration Documentation](https://www.ory.com/docs/kratos/self-service/flows/user-registration).
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class CreateNativeRegistrationFlowExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IFrontendApi>();
+            Option<bool> returnSessionTokenExchangeCode = default!; // EnableSessionTokenExchangeCode requests the login flow to include a code that can be used to retrieve the session token after the login flow has been completed. (optional)
+            Option<string> returnTo = default!; // The URL to return the browser to after the flow was completed. (optional)
+            Option<string> organization = default!; // An optional organization ID that should be used to register this user. This parameter is only effective in the Ory Network. (optional)
+            Option<string> identitySchema = default!; // An optional identity schema to use for the registration flow. (optional)
+            var response = await api.CreateNativeRegistrationFlowAsync(returnSessionTokenExchangeCode, returnTo, organization, identitySchema);
+            ClientRegistrationFlow? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -421,7 +764,7 @@ This endpoint initiates a registration flow for API clients such as mobile devic
 
 ### Return type
 
-[**ClientRegistrationFlow**](ClientRegistrationFlow.md)
+[**ClientRegistrationFlow**](../models/ClientRegistrationFlow.md)
 
 ### Authorization
 
@@ -444,12 +787,45 @@ No authorization required
 
 <a id="createnativesettingsflow"></a>
 # **CreateNativeSettingsFlow**
-> ClientSettingsFlow CreateNativeSettingsFlow (string xSessionToken = null, string organization = null)
+> Task&lt;ICreateNativeSettingsFlowApiResponse&gt; CreateNativeSettingsFlowAsync(Option<string> xSessionToken = default, Option<string> organization = default, System.Threading.CancellationToken cancellationToken = default)
 
 Create Settings Flow for Native Apps
 
 This endpoint initiates a settings flow for API clients such as mobile devices, smart TVs, and so on. You must provide a valid Ory Kratos Session Token for this endpoint to respond with HTTP 200 OK.  To fetch an existing settings flow call `/self-service/settings/flows?flow=<flow_id>`.  You MUST NOT use this endpoint in client-side (Single Page Apps, ReactJS, AngularJS) nor server-side (Java Server Pages, NodeJS, PHP, Golang, ...) browser applications. Using this endpoint in these applications will make you vulnerable to a variety of CSRF attacks.  Depending on your configuration this endpoint might return a 403 error if the session has a lower Authenticator Assurance Level (AAL) than is possible for the identity. This can happen if the identity has password + webauthn credentials (which would result in AAL2) but the session has only AAL1. If this error occurs, ask the user to sign in with the second factor or change the configuration.  In the case of an error, the `error.id` of the JSON response body can be one of:  `security_csrf_violation`: Unable to fetch the flow because a CSRF violation occurred. `session_inactive`: No Ory Session was found - sign in a user first.  This endpoint MUST ONLY be used in scenarios such as native mobile apps (React Native, Objective C, Swift, Java, ...).  More information can be found at [Ory Kratos User Settings & Profile Management Documentation](../self-service/flows/user-settings).
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class CreateNativeSettingsFlowExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IFrontendApi>();
+            Option<string> xSessionToken = default!; // The Session Token of the Identity performing the settings flow. (optional)
+            Option<string> organization = default!; // An optional organization ID that scopes the settings flow to providers of that organization. This parameter is only effective in the Ory Network. (optional)
+            var response = await api.CreateNativeSettingsFlowAsync(xSessionToken, organization);
+            ClientSettingsFlow? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -460,7 +836,7 @@ This endpoint initiates a settings flow for API clients such as mobile devices, 
 
 ### Return type
 
-[**ClientSettingsFlow**](ClientSettingsFlow.md)
+[**ClientSettingsFlow**](../models/ClientSettingsFlow.md)
 
 ### Authorization
 
@@ -483,12 +859,44 @@ No authorization required
 
 <a id="createnativeverificationflow"></a>
 # **CreateNativeVerificationFlow**
-> ClientVerificationFlow CreateNativeVerificationFlow (string returnTo = null)
+> Task&lt;ICreateNativeVerificationFlowApiResponse&gt; CreateNativeVerificationFlowAsync(Option<string> returnTo = default, System.Threading.CancellationToken cancellationToken = default)
 
 Create Verification Flow for Native Apps
 
 This endpoint initiates a verification flow for API clients such as mobile devices, smart TVs, and so on.  To fetch an existing verification flow call `/self-service/verification/flows?flow=<flow_id>`.  You MUST NOT use this endpoint in client-side (Single Page Apps, ReactJS, AngularJS) nor server-side (Java Server Pages, NodeJS, PHP, Golang, ...) browser applications. Using this endpoint in these applications will make you vulnerable to a variety of CSRF attacks.  This endpoint MUST ONLY be used in scenarios such as native mobile apps (React Native, Objective C, Swift, Java, ...).  More information can be found at [Ory Email and Phone Verification Documentation](https://www.ory.com/docs/kratos/self-service/flows/verify-email-account-activation).
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class CreateNativeVerificationFlowExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IFrontendApi>();
+            Option<string> returnTo = default!; // A URL contained in the return_to key of the verification flow. This piece of data has no effect on the actual logic of the flow and is purely informational. (optional)
+            var response = await api.CreateNativeVerificationFlowAsync(returnTo);
+            ClientVerificationFlow? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -498,7 +906,7 @@ This endpoint initiates a verification flow for API clients such as mobile devic
 
 ### Return type
 
-[**ClientVerificationFlow**](ClientVerificationFlow.md)
+[**ClientVerificationFlow**](../models/ClientVerificationFlow.md)
 
 ### Authorization
 
@@ -521,12 +929,44 @@ No authorization required
 
 <a id="deletetestloginflow"></a>
 # **DeleteTestLoginFlow**
-> void DeleteTestLoginFlow (string id, string cookie = null)
+> Task&lt;IDeleteTestLoginFlowApiResponse&gt; DeleteTestLoginFlowAsync(string id, Option<string> cookie = default, System.Threading.CancellationToken cancellationToken = default)
 
 Delete a test OIDC login flow
 
 Deletes a dry-run OIDC test login flow. A flow whose debug payload has been captured requires the HMAC cookie set by the OIDC callback; a flow still in the initial choose-method state is deletable with just the flow ID (it carries no PII, and the admin may want to abandon it).
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class DeleteTestLoginFlowExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IFrontendApi>();
+            string id = default!; // ID of the test login flow to delete.
+            Option<string> cookie = default!; // HTTP Cookies. A captured test flow requires the ory_kratos_test_flow cookie set by the OIDC callback; a flow still in the initial choose-method state does not. (optional)
+            await api.DeleteTestLoginFlowAsync(id, cookie);
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -562,12 +1002,45 @@ No authorization required
 
 <a id="disablemyothersessions"></a>
 # **DisableMyOtherSessions**
-> ClientDeleteMySessionsCount DisableMyOtherSessions (string xSessionToken = null, string cookie = null)
+> Task&lt;IDisableMyOtherSessionsApiResponse&gt; DisableMyOtherSessionsAsync(Option<string> xSessionToken = default, Option<string> cookie = default, System.Threading.CancellationToken cancellationToken = default)
 
 Disable my other sessions
 
 Calling this endpoint invalidates all except the current session that belong to the logged-in user. Session data are not deleted.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class DisableMyOtherSessionsExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IFrontendApi>();
+            Option<string> xSessionToken = default!; // Set the Session Token when calling from non-browser clients. A session token has a format of `MP2YWEMeM8MxjkGKpH4dqOQ4Q4DlSPaj`. (optional)
+            Option<string> cookie = default!; // Set the Cookie Header. This is especially useful when calling this endpoint from a server-side application. In that scenario you must include the HTTP Cookie Header which originally was included in the request to your server. An example of a session in the HTTP Cookie Header is: `ory_kratos_session=a19iOVAbdzdgl70Rq1QZmrKmcjDtdsviCTZx7m9a9yHIUS8Wa9T7hvqyGTsLHi6Qifn2WUfpAKx9DWp0SJGleIn9vh2YF4A16id93kXFTgIgmwIOvbVAScyrx7yVl6bPZnCx27ec4WQDtaTewC1CpgudeDV2jQQnSaCP6ny3xa8qLH-QUgYqdQuoA_LF1phxgRCUfIrCLQOkolX5nv3ze_f==`.  It is ok if more than one cookie are included here as all other cookies will be ignored. (optional)
+            var response = await api.DisableMyOtherSessionsAsync(xSessionToken, cookie);
+            ClientDeleteMySessionsCount? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -578,7 +1051,7 @@ Calling this endpoint invalidates all except the current session that belong to 
 
 ### Return type
 
-[**ClientDeleteMySessionsCount**](ClientDeleteMySessionsCount.md)
+[**ClientDeleteMySessionsCount**](../models/ClientDeleteMySessionsCount.md)
 
 ### Authorization
 
@@ -602,12 +1075,45 @@ No authorization required
 
 <a id="disablemysession"></a>
 # **DisableMySession**
-> void DisableMySession (string id, string xSessionToken = null, string cookie = null)
+> Task&lt;IDisableMySessionApiResponse&gt; DisableMySessionAsync(string id, Option<string> xSessionToken = default, Option<string> cookie = default, System.Threading.CancellationToken cancellationToken = default)
 
 Disable one of my sessions
 
 Calling this endpoint invalidates the specified session. The current session cannot be revoked. Session data are not deleted.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class DisableMySessionExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IFrontendApi>();
+            string id = default!; // ID is the session's ID.
+            Option<string> xSessionToken = default!; // Set the Session Token when calling from non-browser clients. A session token has a format of `MP2YWEMeM8MxjkGKpH4dqOQ4Q4DlSPaj`. (optional)
+            Option<string> cookie = default!; // Set the Cookie Header. This is especially useful when calling this endpoint from a server-side application. In that scenario you must include the HTTP Cookie Header which originally was included in the request to your server. An example of a session in the HTTP Cookie Header is: `ory_kratos_session=a19iOVAbdzdgl70Rq1QZmrKmcjDtdsviCTZx7m9a9yHIUS8Wa9T7hvqyGTsLHi6Qifn2WUfpAKx9DWp0SJGleIn9vh2YF4A16id93kXFTgIgmwIOvbVAScyrx7yVl6bPZnCx27ec4WQDtaTewC1CpgudeDV2jQQnSaCP6ny3xa8qLH-QUgYqdQuoA_LF1phxgRCUfIrCLQOkolX5nv3ze_f==`.  It is ok if more than one cookie are included here as all other cookies will be ignored. (optional)
+            await api.DisableMySessionAsync(id, xSessionToken, cookie);
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -643,10 +1149,43 @@ No authorization required
 
 <a id="exchangesessiontoken"></a>
 # **ExchangeSessionToken**
-> ClientSuccessfulNativeLogin ExchangeSessionToken (string initCode, string returnToCode)
+> Task&lt;IExchangeSessionTokenApiResponse&gt; ExchangeSessionTokenAsync(string initCode, string returnToCode, System.Threading.CancellationToken cancellationToken = default)
 
 Exchange Session Token
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class ExchangeSessionTokenExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IFrontendApi>();
+            string initCode = default!; // The part of the code return when initializing the flow.
+            string returnToCode = default!; // The part of the code returned by the return_to URL.
+            var response = await api.ExchangeSessionTokenAsync(initCode, returnToCode);
+            ClientSuccessfulNativeLogin? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -657,7 +1196,7 @@ Exchange Session Token
 
 ### Return type
 
-[**ClientSuccessfulNativeLogin**](ClientSuccessfulNativeLogin.md)
+[**ClientSuccessfulNativeLogin**](../models/ClientSuccessfulNativeLogin.md)
 
 ### Authorization
 
@@ -683,12 +1222,44 @@ No authorization required
 
 <a id="getflowerror"></a>
 # **GetFlowError**
-> ClientFlowError GetFlowError (string id)
+> Task&lt;IGetFlowErrorApiResponse&gt; GetFlowErrorAsync(string id, System.Threading.CancellationToken cancellationToken = default)
 
 Get User-Flow Errors
 
 This endpoint returns the error associated with a user-facing self service errors.  This endpoint supports stub values to help you implement the error UI:  `?id=stub:500` - returns a stub 500 (Internal Server Error) error.  More information can be found at [Ory Kratos User User Facing Error Documentation](https://www.ory.com/docs/kratos/self-service/flows/user-facing-errors).
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class GetFlowErrorExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IFrontendApi>();
+            string id = default!; // Error is the error's ID
+            var response = await api.GetFlowErrorAsync(id);
+            ClientFlowError? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -698,7 +1269,7 @@ This endpoint returns the error associated with a user-facing self service error
 
 ### Return type
 
-[**ClientFlowError**](ClientFlowError.md)
+[**ClientFlowError**](../models/ClientFlowError.md)
 
 ### Authorization
 
@@ -722,12 +1293,45 @@ No authorization required
 
 <a id="getloginflow"></a>
 # **GetLoginFlow**
-> ClientLoginFlow GetLoginFlow (string id, string cookie = null)
+> Task&lt;IGetLoginFlowApiResponse&gt; GetLoginFlowAsync(string id, Option<string> cookie = default, System.Threading.CancellationToken cancellationToken = default)
 
 Get Login Flow
 
 This endpoint returns a login flow's context with, for example, error details and other information.  Browser flows expect the anti-CSRF cookie to be included in the request's HTTP Cookie Header. For AJAX requests you must ensure that cookies are included in the request or requests will fail.  If you use the browser-flow for server-side apps, the services need to run on a common top-level-domain and you need to forward the incoming HTTP Cookie header to this endpoint:  ```js pseudo-code example router.get('/login', async function (req, res) { const flow = await client.getLoginFlow(req.header('cookie'), req.query['flow'])  res.render('login', flow) }) ```  This request may fail due to several reasons. The `error.id` can be one of:  `session_already_available`: The user is already signed in. `self_service_flow_expired`: The flow is expired and you should request a new one.  More information can be found at [Ory Kratos User Login](https://www.ory.com/docs/kratos/self-service/flows/user-login) and [User Registration Documentation](https://www.ory.com/docs/kratos/self-service/flows/user-registration).
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class GetLoginFlowExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IFrontendApi>();
+            string id = default!; // The Login Flow ID  The value for this parameter comes from `flow` URL Query parameter sent to your application (e.g. `/login?flow=abcde`).
+            Option<string> cookie = default!; // HTTP Cookies  When using the SDK in a browser app, on the server side you must include the HTTP Cookie Header sent by the client to your server here. This ensures that CSRF and session cookies are respected. (optional)
+            var response = await api.GetLoginFlowAsync(id, cookie);
+            ClientLoginFlow? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -738,7 +1342,7 @@ This endpoint returns a login flow's context with, for example, error details an
 
 ### Return type
 
-[**ClientLoginFlow**](ClientLoginFlow.md)
+[**ClientLoginFlow**](../models/ClientLoginFlow.md)
 
 ### Authorization
 
@@ -763,12 +1367,45 @@ No authorization required
 
 <a id="getrecoveryflow"></a>
 # **GetRecoveryFlow**
-> ClientRecoveryFlow GetRecoveryFlow (string id, string cookie = null)
+> Task&lt;IGetRecoveryFlowApiResponse&gt; GetRecoveryFlowAsync(string id, Option<string> cookie = default, System.Threading.CancellationToken cancellationToken = default)
 
 Get Recovery Flow
 
 This endpoint returns a recovery flow's context with, for example, error details and other information.  Browser flows expect the anti-CSRF cookie to be included in the request's HTTP Cookie Header. For AJAX requests you must ensure that cookies are included in the request or requests will fail.  If you use the browser-flow for server-side apps, the services need to run on a common top-level-domain and you need to forward the incoming HTTP Cookie header to this endpoint:  ```js pseudo-code example router.get('/recovery', async function (req, res) { const flow = await client.getRecoveryFlow(req.header('Cookie'), req.query['flow'])  res.render('recovery', flow) }) ```  More information can be found at [Ory Kratos Account Recovery Documentation](../self-service/flows/account-recovery).
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class GetRecoveryFlowExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IFrontendApi>();
+            string id = default!; // The Flow ID  The value for this parameter comes from `request` URL Query parameter sent to your application (e.g. `/recovery?flow=abcde`).
+            Option<string> cookie = default!; // HTTP Cookies  When using the SDK in a browser app, on the server side you must include the HTTP Cookie Header sent by the client to your server here. This ensures that CSRF and session cookies are respected. (optional)
+            var response = await api.GetRecoveryFlowAsync(id, cookie);
+            ClientRecoveryFlow? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -779,7 +1416,7 @@ This endpoint returns a recovery flow's context with, for example, error details
 
 ### Return type
 
-[**ClientRecoveryFlow**](ClientRecoveryFlow.md)
+[**ClientRecoveryFlow**](../models/ClientRecoveryFlow.md)
 
 ### Authorization
 
@@ -803,12 +1440,45 @@ No authorization required
 
 <a id="getregistrationflow"></a>
 # **GetRegistrationFlow**
-> ClientRegistrationFlow GetRegistrationFlow (string id, string cookie = null)
+> Task&lt;IGetRegistrationFlowApiResponse&gt; GetRegistrationFlowAsync(string id, Option<string> cookie = default, System.Threading.CancellationToken cancellationToken = default)
 
 Get Registration Flow
 
 This endpoint returns a registration flow's context with, for example, error details and other information.  Browser flows expect the anti-CSRF cookie to be included in the request's HTTP Cookie Header. For AJAX requests you must ensure that cookies are included in the request or requests will fail.  If you use the browser-flow for server-side apps, the services need to run on a common top-level-domain and you need to forward the incoming HTTP Cookie header to this endpoint:  ```js pseudo-code example router.get('/registration', async function (req, res) { const flow = await client.getRegistrationFlow(req.header('cookie'), req.query['flow'])  res.render('registration', flow) }) ```  This request may fail due to several reasons. The `error.id` can be one of:  `session_already_available`: The user is already signed in. `self_service_flow_expired`: The flow is expired and you should request a new one.  More information can be found at [Ory Kratos User Login](https://www.ory.com/docs/kratos/self-service/flows/user-login) and [User Registration Documentation](https://www.ory.com/docs/kratos/self-service/flows/user-registration).
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class GetRegistrationFlowExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IFrontendApi>();
+            string id = default!; // The Registration Flow ID  The value for this parameter comes from `flow` URL Query parameter sent to your application (e.g. `/registration?flow=abcde`).
+            Option<string> cookie = default!; // HTTP Cookies  When using the SDK in a browser app, on the server side you must include the HTTP Cookie Header sent by the client to your server here. This ensures that CSRF and session cookies are respected. (optional)
+            var response = await api.GetRegistrationFlowAsync(id, cookie);
+            ClientRegistrationFlow? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -819,7 +1489,7 @@ This endpoint returns a registration flow's context with, for example, error det
 
 ### Return type
 
-[**ClientRegistrationFlow**](ClientRegistrationFlow.md)
+[**ClientRegistrationFlow**](../models/ClientRegistrationFlow.md)
 
 ### Authorization
 
@@ -844,12 +1514,46 @@ No authorization required
 
 <a id="getsettingsflow"></a>
 # **GetSettingsFlow**
-> ClientSettingsFlow GetSettingsFlow (string id, string xSessionToken = null, string cookie = null)
+> Task&lt;IGetSettingsFlowApiResponse&gt; GetSettingsFlowAsync(string id, Option<string> xSessionToken = default, Option<string> cookie = default, System.Threading.CancellationToken cancellationToken = default)
 
 Get Settings Flow
 
 When accessing this endpoint through Ory Kratos' Public API you must ensure that either the Ory Kratos Session Cookie or the Ory Kratos Session Token are set.  Depending on your configuration this endpoint might return a 403 error if the session has a lower Authenticator Assurance Level (AAL) than is possible for the identity. This can happen if the identity has password + webauthn credentials (which would result in AAL2) but the session has only AAL1. If this error occurs, ask the user to sign in with the second factor or change the configuration.  You can access this endpoint without credentials when using Ory Kratos' Admin API.  If this endpoint is called via an AJAX request, the response contains the flow without a redirect. In the case of an error, the `error.id` of the JSON response body can be one of:  `security_csrf_violation`: Unable to fetch the flow because a CSRF violation occurred. `session_inactive`: No Ory Session was found - sign in a user first. `security_identity_mismatch`: The flow was interrupted with `session_refresh_required` but apparently some other identity logged in instead.  More information can be found at [Ory Kratos User Settings & Profile Management Documentation](../self-service/flows/user-settings).
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class GetSettingsFlowExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IFrontendApi>();
+            string id = default!; // ID is the Settings Flow ID  The value for this parameter comes from `flow` URL Query parameter sent to your application (e.g. `/settings?flow=abcde`).
+            Option<string> xSessionToken = default!; // The Session Token  When using the SDK in an app without a browser, please include the session token here. (optional)
+            Option<string> cookie = default!; // HTTP Cookies  When using the SDK in a browser app, on the server side you must include the HTTP Cookie Header sent by the client to your server here. This ensures that CSRF and session cookies are respected. (optional)
+            var response = await api.GetSettingsFlowAsync(id, xSessionToken, cookie);
+            ClientSettingsFlow? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -861,7 +1565,7 @@ When accessing this endpoint through Ory Kratos' Public API you must ensure that
 
 ### Return type
 
-[**ClientSettingsFlow**](ClientSettingsFlow.md)
+[**ClientSettingsFlow**](../models/ClientSettingsFlow.md)
 
 ### Authorization
 
@@ -887,12 +1591,45 @@ No authorization required
 
 <a id="getverificationflow"></a>
 # **GetVerificationFlow**
-> ClientVerificationFlow GetVerificationFlow (string id, string cookie = null)
+> Task&lt;IGetVerificationFlowApiResponse&gt; GetVerificationFlowAsync(string id, Option<string> cookie = default, System.Threading.CancellationToken cancellationToken = default)
 
 Get Verification Flow
 
 This endpoint returns a verification flow's context with, for example, error details and other information.  Browser flows expect the anti-CSRF cookie to be included in the request's HTTP Cookie Header. For AJAX requests you must ensure that cookies are included in the request or requests will fail.  If you use the browser-flow for server-side apps, the services need to run on a common top-level-domain and you need to forward the incoming HTTP Cookie header to this endpoint:  ```js pseudo-code example router.get('/recovery', async function (req, res) { const flow = await client.getVerificationFlow(req.header('cookie'), req.query['flow'])  res.render('verification', flow) }) ```  More information can be found at [Ory Kratos Email and Phone Verification Documentation](https://www.ory.com/docs/kratos/self-service/flows/verify-email-account-activation).
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class GetVerificationFlowExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IFrontendApi>();
+            string id = default!; // The Flow ID  The value for this parameter comes from `request` URL Query parameter sent to your application (e.g. `/verification?flow=abcde`).
+            Option<string> cookie = default!; // HTTP Cookies  When using the SDK on the server side you must include the HTTP Cookie Header originally sent to your HTTP handler here. (optional)
+            var response = await api.GetVerificationFlowAsync(id, cookie);
+            ClientVerificationFlow? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -903,7 +1640,7 @@ This endpoint returns a verification flow's context with, for example, error det
 
 ### Return type
 
-[**ClientVerificationFlow**](ClientVerificationFlow.md)
+[**ClientVerificationFlow**](../models/ClientVerificationFlow.md)
 
 ### Authorization
 
@@ -927,12 +1664,43 @@ No authorization required
 
 <a id="getwebauthnjavascript"></a>
 # **GetWebAuthnJavaScript**
-> string GetWebAuthnJavaScript ()
+> Task&lt;IGetWebAuthnJavaScriptApiResponse&gt; GetWebAuthnJavaScriptAsync(System.Threading.CancellationToken cancellationToken = default)
 
 Get WebAuthn JavaScript
 
 This endpoint provides JavaScript which is needed in order to perform WebAuthn login and registration.  If you are building a JavaScript Browser App (e.g. in ReactJS or AngularJS) you will need to load this file:  ```html <script src=\"https://public-kratos.example.org/.well-known/ory/webauthn.js\" type=\"script\" async /> ```  More information can be found at [Ory Kratos User Login](https://www.ory.com/docs/kratos/self-service/flows/user-login) and [User Registration Documentation](https://www.ory.com/docs/kratos/self-service/flows/user-registration).
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class GetWebAuthnJavaScriptExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IFrontendApi>();
+            var response = await api.GetWebAuthnJavaScriptAsync();
+            string? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 This endpoint does not need any parameter.
@@ -959,18 +1727,48 @@ No authorization required
 
 <a id="getwellknownchangepassword"></a>
 # **GetWellKnownChangePassword**
-> ClientErrorGeneric GetWellKnownChangePassword ()
+> Task&lt;IGetWellKnownChangePasswordApiResponse&gt; GetWellKnownChangePasswordAsync(System.Threading.CancellationToken cancellationToken = default)
 
 Change Password URL
 
 This endpoint implements the W3C \"change password URL\" well-known location by redirecting the browser to the configured settings UI. Password managers follow this redirect to take users straight to the page where they can change their password.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class GetWellKnownChangePasswordExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IFrontendApi>();
+            await api.GetWellKnownChangePasswordAsync();
+        }
+    }
+}
+```
 
 ### Parameters
 This endpoint does not need any parameter.
 ### Return type
 
-[**ClientErrorGeneric**](ClientErrorGeneric.md)
+[**ClientErrorGeneric**](../models/ClientErrorGeneric.md)
 
 ### Authorization
 
@@ -992,12 +1790,49 @@ No authorization required
 
 <a id="listmysessions"></a>
 # **ListMySessions**
-> List&lt;ClientSession&gt; ListMySessions (long perPage = null, long page = null, long pageSize = null, string pageToken = null, string xSessionToken = null, string cookie = null)
+> Task&lt;IListMySessionsApiResponse&gt; ListMySessionsAsync(Option<long> perPage = default, Option<long> page = default, Option<long> pageSize = default, Option<string> pageToken = default, Option<string> xSessionToken = default, Option<string> cookie = default, System.Threading.CancellationToken cancellationToken = default)
 
 Get My Active Sessions
 
 This endpoints returns all other active sessions that belong to the logged-in user. The current session can be retrieved by calling the `/sessions/whoami` endpoint.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class ListMySessionsExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IFrontendApi>();
+            Option<long> perPage = default!; // Deprecated Items per Page  DEPRECATED: Please use `page_token` instead. This parameter will be removed in the future.  This is the number of items per page. (optional)
+            Option<long> page = default!; // Deprecated Pagination Page  DEPRECATED: Please use `page_token` instead. This parameter will be removed in the future.  This value is currently an integer, but it is not sequential. The value is not the page number, but a reference. The next page can be any number and some numbers might return an empty list.  For example, page 2 might not follow after page 1. And even if page 3 and 5 exist, but page 4 might not exist. The first page can be retrieved by omitting this parameter. Following page pointers will be returned in the `Link` header. (optional)
+            Option<long> pageSize = default!; // Page Size  This is the number of items per page to return. For details on pagination please head over to the [pagination documentation](https://www.ory.com/docs/ecosystem/api-design#pagination). (optional)
+            Option<string> pageToken = default!; // Next Page Token  The next page token. For details on pagination please head over to the [pagination documentation](https://www.ory.com/docs/ecosystem/api-design#pagination). (optional)
+            Option<string> xSessionToken = default!; // Set the Session Token when calling from non-browser clients. A session token has a format of `MP2YWEMeM8MxjkGKpH4dqOQ4Q4DlSPaj`. (optional)
+            Option<string> cookie = default!; // Set the Cookie Header. This is especially useful when calling this endpoint from a server-side application. In that scenario you must include the HTTP Cookie Header which originally was included in the request to your server. An example of a session in the HTTP Cookie Header is: `ory_kratos_session=a19iOVAbdzdgl70Rq1QZmrKmcjDtdsviCTZx7m9a9yHIUS8Wa9T7hvqyGTsLHi6Qifn2WUfpAKx9DWp0SJGleIn9vh2YF4A16id93kXFTgIgmwIOvbVAScyrx7yVl6bPZnCx27ec4WQDtaTewC1CpgudeDV2jQQnSaCP6ny3xa8qLH-QUgYqdQuoA_LF1phxgRCUfIrCLQOkolX5nv3ze_f==`.  It is ok if more than one cookie are included here as all other cookies will be ignored. (optional)
+            var response = await api.ListMySessionsAsync(perPage, page, pageSize, pageToken, xSessionToken, cookie);
+            List<ClientSession>? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -1012,7 +1847,7 @@ This endpoints returns all other active sessions that belong to the logged-in us
 
 ### Return type
 
-[**List&lt;ClientSession&gt;**](ClientSession.md)
+[**List&lt;ClientSession&gt;**](../models/ClientSession.md)
 
 ### Authorization
 
@@ -1036,18 +1871,49 @@ No authorization required
 
 <a id="performnativelogout"></a>
 # **PerformNativeLogout**
-> void PerformNativeLogout (ClientPerformNativeLogoutBody clientPerformNativeLogoutBody)
+> Task&lt;IPerformNativeLogoutApiResponse&gt; PerformNativeLogoutAsync(ClientPerformNativeLogoutBody clientPerformNativeLogoutBody, System.Threading.CancellationToken cancellationToken = default)
 
 Perform Logout for Native Apps
 
 Use this endpoint to log out an identity using an Ory Session Token. If the Ory Session Token was successfully revoked, the server returns a 204 No Content response. A 204 No Content response is also sent when the Ory Session Token has been revoked already before.  If the Ory Session Token is malformed or does not exist a 403 Forbidden response will be returned.  This endpoint does not remove any HTTP Cookies - use the Browser-Based Self-Service Logout Flow instead.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class PerformNativeLogoutExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IFrontendApi>();
+            ClientPerformNativeLogoutBody clientPerformNativeLogoutBody = default!; // 
+            await api.PerformNativeLogoutAsync(clientPerformNativeLogoutBody);
+        }
+    }
+}
+```
 
 ### Parameters
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **clientPerformNativeLogoutBody** | [**ClientPerformNativeLogoutBody**](ClientPerformNativeLogoutBody.md) |  |  |
+| **clientPerformNativeLogoutBody** | [**ClientPerformNativeLogoutBody**](../models/ClientPerformNativeLogoutBody.md) |  |  |
 
 ### Return type
 
@@ -1074,12 +1940,46 @@ No authorization required
 
 <a id="tosession"></a>
 # **ToSession**
-> ClientSession ToSession (string xSessionToken = null, string cookie = null, string tokenizeAs = null)
+> Task&lt;IToSessionApiResponse&gt; ToSessionAsync(Option<string> xSessionToken = default, Option<string> cookie = default, Option<string> tokenizeAs = default, System.Threading.CancellationToken cancellationToken = default)
 
 Check Who the Current HTTP Session Belongs To
 
 Uses the HTTP Headers in the GET request to determine (e.g. by using checking the cookies) who is authenticated. Returns a session object in the body or 401 if the credentials are invalid or no credentials were sent. When the request it successful it adds the user ID to the 'X-Kratos-Authenticated-Identity-Id' header in the response.  If you call this endpoint from a server-side application, you must forward the HTTP Cookie Header to this endpoint:  ```js pseudo-code example router.get('/protected-endpoint', async function (req, res) { const session = await client.toSession(undefined, req.header('cookie'))  console.log(session) }) ```  When calling this endpoint from a non-browser application (e.g. mobile app) you must include the session token:  ```js pseudo-code example ... const session = await client.toSession(\"the-session-token\")  console.log(session) ```  When using a token template, the token is included in the `tokenized` field of the session.  ```js pseudo-code example ... const session = await client.toSession(\"the-session-token\", { tokenize_as: \"example-jwt-template\" })  console.log(session.tokenized) // The JWT ```  Depending on your configuration this endpoint might return a 403 status code if the session has a lower Authenticator Assurance Level (AAL) than is possible for the identity. This can happen if the identity has password + webauthn credentials (which would result in AAL2) but the session has only AAL1. If this error occurs, ask the user to sign in with the second factor or change the configuration.  This endpoint is useful for:  AJAX calls. Remember to send credentials and set up CORS correctly! Reverse proxies and API Gateways Server-side calls - use the `X-Session-Token` header!  This endpoint authenticates users by checking:  if the `Cookie` HTTP header was set containing an Ory Kratos Session Cookie; if the `Authorization: bearer <ory-session-token>` HTTP header was set with a valid Ory Kratos Session Token; if the `X-Session-Token` HTTP header was set with a valid Ory Kratos Session Token.  If none of these headers are set or the cookie or token are invalid, the endpoint returns a HTTP 401 status code.  As explained above, this request may fail due to several reasons. The `error.id` can be one of:  `session_inactive`: No active session was found in the request (e.g. no Ory Session Cookie / Ory Session Token). `session_aal2_required`: An active session was found but it does not fulfil the Authenticator Assurance Level, implying that the session must (e.g.) authenticate the second factor.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class ToSessionExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IFrontendApi>();
+            Option<string> xSessionToken = default!; // Set the Session Token when calling from non-browser clients. A session token has a format of `MP2YWEMeM8MxjkGKpH4dqOQ4Q4DlSPaj`. (optional)
+            Option<string> cookie = default!; // Set the Cookie Header. This is especially useful when calling this endpoint from a server-side application. In that scenario you must include the HTTP Cookie Header which originally was included in the request to your server. An example of a session in the HTTP Cookie Header is: `ory_kratos_session=a19iOVAbdzdgl70Rq1QZmrKmcjDtdsviCTZx7m9a9yHIUS8Wa9T7hvqyGTsLHi6Qifn2WUfpAKx9DWp0SJGleIn9vh2YF4A16id93kXFTgIgmwIOvbVAScyrx7yVl6bPZnCx27ec4WQDtaTewC1CpgudeDV2jQQnSaCP6ny3xa8qLH-QUgYqdQuoA_LF1phxgRCUfIrCLQOkolX5nv3ze_f==`.  It is ok if more than one cookie are included here as all other cookies will be ignored. (optional)
+            Option<string> tokenizeAs = default!; // Returns the session additionally as a token (such as a JWT)  The value of this parameter has to be a valid, configured Ory Session token template. For more information head over to [the documentation](http://ory.sh/docs/identities/session-to-jwt-cors). (optional)
+            var response = await api.ToSessionAsync(xSessionToken, cookie, tokenizeAs);
+            ClientSession? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -1091,7 +1991,7 @@ Uses the HTTP Headers in the GET request to determine (e.g. by using checking th
 
 ### Return type
 
-[**ClientSession**](ClientSession.md)
+[**ClientSession**](../models/ClientSession.md)
 
 ### Authorization
 
@@ -1115,22 +2015,54 @@ No authorization required
 
 <a id="updatefedcmflow"></a>
 # **UpdateFedcmFlow**
-> ClientSuccessfulNativeLogin UpdateFedcmFlow (ClientUpdateFedcmFlowBody clientUpdateFedcmFlowBody)
+> Task&lt;IUpdateFedcmFlowApiResponse&gt; UpdateFedcmFlowAsync(ClientUpdateFedcmFlowBody clientUpdateFedcmFlowBody, System.Threading.CancellationToken cancellationToken = default)
 
 Submit a FedCM token
 
 Use this endpoint to submit a token from a FedCM provider through `navigator.credentials.get` and log the user in. The parameters from `navigator.credentials.get` must have come from `GET self-service/fed-cm/parameters`.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class UpdateFedcmFlowExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IFrontendApi>();
+            ClientUpdateFedcmFlowBody clientUpdateFedcmFlowBody = default!; // 
+            var response = await api.UpdateFedcmFlowAsync(clientUpdateFedcmFlowBody);
+            ClientSuccessfulNativeLogin? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **clientUpdateFedcmFlowBody** | [**ClientUpdateFedcmFlowBody**](ClientUpdateFedcmFlowBody.md) |  |  |
+| **clientUpdateFedcmFlowBody** | [**ClientUpdateFedcmFlowBody**](../models/ClientUpdateFedcmFlowBody.md) |  |  |
 
 ### Return type
 
-[**ClientSuccessfulNativeLogin**](ClientSuccessfulNativeLogin.md)
+[**ClientSuccessfulNativeLogin**](../models/ClientSuccessfulNativeLogin.md)
 
 ### Authorization
 
@@ -1156,25 +2088,60 @@ No authorization required
 
 <a id="updateloginflow"></a>
 # **UpdateLoginFlow**
-> ClientSuccessfulNativeLogin UpdateLoginFlow (string flow, ClientUpdateLoginFlowBody clientUpdateLoginFlowBody, string xSessionToken = null, string cookie = null)
+> Task&lt;IUpdateLoginFlowApiResponse&gt; UpdateLoginFlowAsync(string flow, ClientUpdateLoginFlowBody clientUpdateLoginFlowBody, Option<string> xSessionToken = default, Option<string> cookie = default, System.Threading.CancellationToken cancellationToken = default)
 
 Submit a Login Flow
 
 Use this endpoint to complete a login flow. This endpoint behaves differently for API and browser flows.  API flows expect `application/json` to be sent in the body and responds with HTTP 200 and a application/json body with the session token on success; HTTP 410 if the original flow expired with the appropriate error messages set and optionally a `use_flow_id` parameter in the body; HTTP 400 on form validation errors.  Browser flows expect a Content-Type of `application/x-www-form-urlencoded` or `application/json` to be sent in the body and respond with a HTTP 303 redirect to the post/after login URL or the `return_to` value if it was set and if the login succeeded; a HTTP 303 redirect to the login UI URL with the flow ID containing the validation errors otherwise.  Browser flows with an accept header of `application/json` will not redirect but instead respond with HTTP 200 and a application/json body with the signed in identity and a `Set-Cookie` header on success; HTTP 303 redirect to a fresh login flow if the original flow expired with the appropriate error messages set; HTTP 400 on form validation errors.  If this endpoint is called with `Accept: application/json` in the header, the response contains the flow without a redirect. In the case of an error, the `error.id` of the JSON response body can be one of:  `session_already_available`: The user is already signed in. `security_csrf_violation`: Unable to fetch the flow because a CSRF violation occurred. `security_identity_mismatch`: The requested `?return_to` address is not allowed to be used. Adjust this in the configuration! `browser_location_change_required`: Usually sent when an AJAX request indicates that the browser needs to open a specific URL. Most likely used in Social Sign In flows.  More information can be found at [Ory Kratos User Login](https://www.ory.com/docs/kratos/self-service/flows/user-login) and [User Registration Documentation](https://www.ory.com/docs/kratos/self-service/flows/user-registration).
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class UpdateLoginFlowExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IFrontendApi>();
+            string flow = default!; // The Login Flow ID  The value for this parameter comes from `flow` URL Query parameter sent to your application (e.g. `/login?flow=abcde`).
+            ClientUpdateLoginFlowBody clientUpdateLoginFlowBody = default!; // 
+            Option<string> xSessionToken = default!; // The Session Token of the Identity performing the settings flow. (optional)
+            Option<string> cookie = default!; // HTTP Cookies  When using the SDK in a browser app, on the server side you must include the HTTP Cookie Header sent by the client to your server here. This ensures that CSRF and session cookies are respected. (optional)
+            var response = await api.UpdateLoginFlowAsync(flow, clientUpdateLoginFlowBody, xSessionToken, cookie);
+            ClientSuccessfulNativeLogin? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
 | **flow** | **string** | The Login Flow ID  The value for this parameter comes from &#x60;flow&#x60; URL Query parameter sent to your application (e.g. &#x60;/login?flow&#x3D;abcde&#x60;). |  |
-| **clientUpdateLoginFlowBody** | [**ClientUpdateLoginFlowBody**](ClientUpdateLoginFlowBody.md) |  |  |
+| **clientUpdateLoginFlowBody** | [**ClientUpdateLoginFlowBody**](../models/ClientUpdateLoginFlowBody.md) |  |  |
 | **xSessionToken** | **string** | The Session Token of the Identity performing the settings flow. | [optional]  |
 | **cookie** | **string** | HTTP Cookies  When using the SDK in a browser app, on the server side you must include the HTTP Cookie Header sent by the client to your server here. This ensures that CSRF and session cookies are respected. | [optional]  |
 
 ### Return type
 
-[**ClientSuccessfulNativeLogin**](ClientSuccessfulNativeLogin.md)
+[**ClientSuccessfulNativeLogin**](../models/ClientSuccessfulNativeLogin.md)
 
 ### Authorization
 
@@ -1200,12 +2167,45 @@ No authorization required
 
 <a id="updatelogoutflow"></a>
 # **UpdateLogoutFlow**
-> void UpdateLogoutFlow (string token = null, string returnTo = null, string cookie = null)
+> Task&lt;IUpdateLogoutFlowApiResponse&gt; UpdateLogoutFlowAsync(Option<string> token = default, Option<string> returnTo = default, Option<string> cookie = default, System.Threading.CancellationToken cancellationToken = default)
 
 Update Logout Flow
 
 This endpoint logs out an identity in a self-service manner.  If the `Accept` HTTP header is not set to `application/json`, the browser will be redirected (HTTP 303 See Other) to the `return_to` parameter of the initial request or fall back to `urls.default_return_to`.  If the `Accept` HTTP header is set to `application/json`, a 204 No Content response will be sent on successful logout instead.  This endpoint is NOT INTENDED for API clients and only works with browsers (Chrome, Firefox, ...). For API clients you can call the `/self-service/logout/api` URL directly with the Ory Session Token.  More information can be found at [Ory Kratos User Logout Documentation](https://www.ory.com/docs/next/kratos/self-service/flows/user-logout).
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class UpdateLogoutFlowExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IFrontendApi>();
+            Option<string> token = default!; // A Valid Logout Token  If you do not have a logout token because you only have a session cookie, call `/self-service/logout/browser` to generate a URL for this endpoint. (optional)
+            Option<string> returnTo = default!; // The URL to return to after the logout was completed. (optional)
+            Option<string> cookie = default!; // HTTP Cookies  When using the SDK in a browser app, on the server side you must include the HTTP Cookie Header sent by the client to your server here. This ensures that CSRF and session cookies are respected. (optional)
+            await api.UpdateLogoutFlowAsync(token, returnTo, cookie);
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -1240,25 +2240,60 @@ No authorization required
 
 <a id="updaterecoveryflow"></a>
 # **UpdateRecoveryFlow**
-> ClientRecoveryFlow UpdateRecoveryFlow (string flow, ClientUpdateRecoveryFlowBody clientUpdateRecoveryFlowBody, string token = null, string cookie = null)
+> Task&lt;IUpdateRecoveryFlowApiResponse&gt; UpdateRecoveryFlowAsync(string flow, ClientUpdateRecoveryFlowBody clientUpdateRecoveryFlowBody, Option<string> token = default, Option<string> cookie = default, System.Threading.CancellationToken cancellationToken = default)
 
 Update Recovery Flow
 
 Use this endpoint to update a recovery flow. This endpoint behaves differently for API and browser flows and has several states:  `choose_method` expects `flow` (in the URL query) and `email` (in the body) to be sent and works with API- and Browser-initiated flows. For API clients and Browser clients with HTTP Header `Accept: application/json` it either returns a HTTP 200 OK when the form is valid and HTTP 400 OK when the form is invalid. and a HTTP 303 See Other redirect with a fresh recovery flow if the flow was otherwise invalid (e.g. expired). For Browser clients without HTTP Header `Accept` or with `Accept: text/_*` it returns a HTTP 303 See Other redirect to the Recovery UI URL with the Recovery Flow ID appended. `sent_email` is the success state after `choose_method` for the `link` method and allows the user to request another recovery email. It works for both API and Browser-initiated flows and returns the same responses as the flow in `choose_method` state. `passed_challenge` expects a `token` to be sent in the URL query and given the nature of the flow (\"sending a recovery link\") does not have any API capabilities. The server responds with a HTTP 303 See Other redirect either to the Settings UI URL (if the link was valid) and instructs the user to update their password, or a redirect to the Recover UI URL with a new Recovery Flow ID which contains an error message that the recovery link was invalid.  More information can be found at [Ory Kratos Account Recovery Documentation](../self-service/flows/account-recovery).
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class UpdateRecoveryFlowExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IFrontendApi>();
+            string flow = default!; // The Recovery Flow ID  The value for this parameter comes from `flow` URL Query parameter sent to your application (e.g. `/recovery?flow=abcde`).
+            ClientUpdateRecoveryFlowBody clientUpdateRecoveryFlowBody = default!; // 
+            Option<string> token = default!; // Recovery Token  The recovery token which completes the recovery request. If the token is invalid (e.g. expired) an error will be shown to the end-user.  This parameter is usually set in a link and not used by any direct API call. (optional)
+            Option<string> cookie = default!; // HTTP Cookies  When using the SDK in a browser app, on the server side you must include the HTTP Cookie Header sent by the client to your server here. This ensures that CSRF and session cookies are respected. (optional)
+            var response = await api.UpdateRecoveryFlowAsync(flow, clientUpdateRecoveryFlowBody, token, cookie);
+            ClientRecoveryFlow? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
 | **flow** | **string** | The Recovery Flow ID  The value for this parameter comes from &#x60;flow&#x60; URL Query parameter sent to your application (e.g. &#x60;/recovery?flow&#x3D;abcde&#x60;). |  |
-| **clientUpdateRecoveryFlowBody** | [**ClientUpdateRecoveryFlowBody**](ClientUpdateRecoveryFlowBody.md) |  |  |
+| **clientUpdateRecoveryFlowBody** | [**ClientUpdateRecoveryFlowBody**](../models/ClientUpdateRecoveryFlowBody.md) |  |  |
 | **token** | **string** | Recovery Token  The recovery token which completes the recovery request. If the token is invalid (e.g. expired) an error will be shown to the end-user.  This parameter is usually set in a link and not used by any direct API call. | [optional]  |
 | **cookie** | **string** | HTTP Cookies  When using the SDK in a browser app, on the server side you must include the HTTP Cookie Header sent by the client to your server here. This ensures that CSRF and session cookies are respected. | [optional]  |
 
 ### Return type
 
-[**ClientRecoveryFlow**](ClientRecoveryFlow.md)
+[**ClientRecoveryFlow**](../models/ClientRecoveryFlow.md)
 
 ### Authorization
 
@@ -1284,24 +2319,58 @@ No authorization required
 
 <a id="updateregistrationflow"></a>
 # **UpdateRegistrationFlow**
-> ClientSuccessfulNativeRegistration UpdateRegistrationFlow (string flow, ClientUpdateRegistrationFlowBody clientUpdateRegistrationFlowBody, string cookie = null)
+> Task&lt;IUpdateRegistrationFlowApiResponse&gt; UpdateRegistrationFlowAsync(string flow, ClientUpdateRegistrationFlowBody clientUpdateRegistrationFlowBody, Option<string> cookie = default, System.Threading.CancellationToken cancellationToken = default)
 
 Update Registration Flow
 
 Use this endpoint to complete a registration flow by sending an identity's traits and password. This endpoint behaves differently for API and browser flows.  API flows expect `application/json` to be sent in the body and respond with HTTP 200 and a application/json body with the created identity success - if the session hook is configured the `session` and `session_token` will also be included; HTTP 410 if the original flow expired with the appropriate error messages set and optionally a `use_flow_id` parameter in the body; HTTP 400 on form validation errors.  Browser flows expect a Content-Type of `application/x-www-form-urlencoded` or `application/json` to be sent in the body and respond with a HTTP 303 redirect to the post/after registration URL or the `return_to` value if it was set and if the registration succeeded; a HTTP 303 redirect to the registration UI URL with the flow ID containing the validation errors otherwise.  Browser flows with an accept header of `application/json` will not redirect but instead respond with HTTP 200 and a application/json body with the signed in identity and a `Set-Cookie` header on success; HTTP 303 redirect to a fresh login flow if the original flow expired with the appropriate error messages set; HTTP 400 on form validation errors.  If this endpoint is called with `Accept: application/json` in the header, the response contains the flow without a redirect. In the case of an error, the `error.id` of the JSON response body can be one of:  `session_already_available`: The user is already signed in. `security_csrf_violation`: Unable to fetch the flow because a CSRF violation occurred. `security_identity_mismatch`: The requested `?return_to` address is not allowed to be used. Adjust this in the configuration! `browser_location_change_required`: Usually sent when an AJAX request indicates that the browser needs to open a specific URL. Most likely used in Social Sign In flows.  More information can be found at [Ory Kratos User Login](https://www.ory.com/docs/kratos/self-service/flows/user-login) and [User Registration Documentation](https://www.ory.com/docs/kratos/self-service/flows/user-registration).
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class UpdateRegistrationFlowExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IFrontendApi>();
+            string flow = default!; // The Registration Flow ID  The value for this parameter comes from `flow` URL Query parameter sent to your application (e.g. `/registration?flow=abcde`).
+            ClientUpdateRegistrationFlowBody clientUpdateRegistrationFlowBody = default!; // 
+            Option<string> cookie = default!; // HTTP Cookies  When using the SDK in a browser app, on the server side you must include the HTTP Cookie Header sent by the client to your server here. This ensures that CSRF and session cookies are respected. (optional)
+            var response = await api.UpdateRegistrationFlowAsync(flow, clientUpdateRegistrationFlowBody, cookie);
+            ClientSuccessfulNativeRegistration? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
 | **flow** | **string** | The Registration Flow ID  The value for this parameter comes from &#x60;flow&#x60; URL Query parameter sent to your application (e.g. &#x60;/registration?flow&#x3D;abcde&#x60;). |  |
-| **clientUpdateRegistrationFlowBody** | [**ClientUpdateRegistrationFlowBody**](ClientUpdateRegistrationFlowBody.md) |  |  |
+| **clientUpdateRegistrationFlowBody** | [**ClientUpdateRegistrationFlowBody**](../models/ClientUpdateRegistrationFlowBody.md) |  |  |
 | **cookie** | **string** | HTTP Cookies  When using the SDK in a browser app, on the server side you must include the HTTP Cookie Header sent by the client to your server here. This ensures that CSRF and session cookies are respected. | [optional]  |
 
 ### Return type
 
-[**ClientSuccessfulNativeRegistration**](ClientSuccessfulNativeRegistration.md)
+[**ClientSuccessfulNativeRegistration**](../models/ClientSuccessfulNativeRegistration.md)
 
 ### Authorization
 
@@ -1327,25 +2396,60 @@ No authorization required
 
 <a id="updatesettingsflow"></a>
 # **UpdateSettingsFlow**
-> ClientSettingsFlow UpdateSettingsFlow (string flow, ClientUpdateSettingsFlowBody clientUpdateSettingsFlowBody, string xSessionToken = null, string cookie = null)
+> Task&lt;IUpdateSettingsFlowApiResponse&gt; UpdateSettingsFlowAsync(string flow, ClientUpdateSettingsFlowBody clientUpdateSettingsFlowBody, Option<string> xSessionToken = default, Option<string> cookie = default, System.Threading.CancellationToken cancellationToken = default)
 
 Complete Settings Flow
 
 Use this endpoint to complete a settings flow by sending an identity's updated password. This endpoint behaves differently for API and browser flows.  API-initiated flows expect `application/json` to be sent in the body and respond with HTTP 200 and an application/json body with the session token on success; HTTP 303 redirect to a fresh settings flow if the original flow expired with the appropriate error messages set; HTTP 400 on form validation errors. HTTP 401 when the endpoint is called without a valid session token. HTTP 403 when `selfservice.flows.settings.privileged_session_max_age` was reached or the session's AAL is too low. Implies that the user needs to re-authenticate.  Browser flows without HTTP Header `Accept` or with `Accept: text/_*` respond with a HTTP 303 redirect to the post/after settings URL or the `return_to` value if it was set and if the flow succeeded; a HTTP 303 redirect to the Settings UI URL with the flow ID containing the validation errors otherwise. a HTTP 303 redirect to the login endpoint when `selfservice.flows.settings.privileged_session_max_age` was reached or the session's AAL is too low.  Browser flows with HTTP Header `Accept: application/json` respond with HTTP 200 and a application/json body with the signed in identity and a `Set-Cookie` header on success; HTTP 303 redirect to a fresh login flow if the original flow expired with the appropriate error messages set; HTTP 401 when the endpoint is called without a valid session cookie. HTTP 403 when the page is accessed without a session cookie or the session's AAL is too low. HTTP 400 on form validation errors.  Depending on your configuration this endpoint might return a 403 error if the session has a lower Authenticator Assurance Level (AAL) than is possible for the identity. This can happen if the identity has password + webauthn credentials (which would result in AAL2) but the session has only AAL1. If this error occurs, ask the user to sign in with the second factor (happens automatically for server-side browser flows) or change the configuration.  If this endpoint is called with a `Accept: application/json` HTTP header, the response contains the flow without a redirect. In the case of an error, the `error.id` of the JSON response body can be one of:  `session_refresh_required`: The identity requested to change something that needs a privileged session. Redirect the identity to the login init endpoint with query parameters `?refresh=true&return_to=<the-current-browser-url>`, or initiate a refresh login flow otherwise. `security_csrf_violation`: Unable to fetch the flow because a CSRF violation occurred. `session_inactive`: No Ory Session was found - sign in a user first. `security_identity_mismatch`: The flow was interrupted with `session_refresh_required` but apparently some other identity logged in instead. `security_identity_mismatch`: The requested `?return_to` address is not allowed to be used. Adjust this in the configuration! `browser_location_change_required`: Usually sent when an AJAX request indicates that the browser needs to open a specific URL. Most likely used in Social Sign In flows.  More information can be found at [Ory Kratos User Settings & Profile Management Documentation](../self-service/flows/user-settings).
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class UpdateSettingsFlowExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IFrontendApi>();
+            string flow = default!; // The Settings Flow ID  The value for this parameter comes from `flow` URL Query parameter sent to your application (e.g. `/settings?flow=abcde`).
+            ClientUpdateSettingsFlowBody clientUpdateSettingsFlowBody = default!; // 
+            Option<string> xSessionToken = default!; // The Session Token of the Identity performing the settings flow. (optional)
+            Option<string> cookie = default!; // HTTP Cookies  When using the SDK in a browser app, on the server side you must include the HTTP Cookie Header sent by the client to your server here. This ensures that CSRF and session cookies are respected. (optional)
+            var response = await api.UpdateSettingsFlowAsync(flow, clientUpdateSettingsFlowBody, xSessionToken, cookie);
+            ClientSettingsFlow? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
 | **flow** | **string** | The Settings Flow ID  The value for this parameter comes from &#x60;flow&#x60; URL Query parameter sent to your application (e.g. &#x60;/settings?flow&#x3D;abcde&#x60;). |  |
-| **clientUpdateSettingsFlowBody** | [**ClientUpdateSettingsFlowBody**](ClientUpdateSettingsFlowBody.md) |  |  |
+| **clientUpdateSettingsFlowBody** | [**ClientUpdateSettingsFlowBody**](../models/ClientUpdateSettingsFlowBody.md) |  |  |
 | **xSessionToken** | **string** | The Session Token of the Identity performing the settings flow. | [optional]  |
 | **cookie** | **string** | HTTP Cookies  When using the SDK in a browser app, on the server side you must include the HTTP Cookie Header sent by the client to your server here. This ensures that CSRF and session cookies are respected. | [optional]  |
 
 ### Return type
 
-[**ClientSettingsFlow**](ClientSettingsFlow.md)
+[**ClientSettingsFlow**](../models/ClientSettingsFlow.md)
 
 ### Authorization
 
@@ -1373,25 +2477,60 @@ No authorization required
 
 <a id="updateverificationflow"></a>
 # **UpdateVerificationFlow**
-> ClientVerificationFlow UpdateVerificationFlow (string flow, ClientUpdateVerificationFlowBody clientUpdateVerificationFlowBody, string token = null, string cookie = null)
+> Task&lt;IUpdateVerificationFlowApiResponse&gt; UpdateVerificationFlowAsync(string flow, ClientUpdateVerificationFlowBody clientUpdateVerificationFlowBody, Option<string> token = default, Option<string> cookie = default, System.Threading.CancellationToken cancellationToken = default)
 
 Complete Verification Flow
 
 Use this endpoint to complete a verification flow. This endpoint behaves differently for API and browser flows and has several states:  `choose_method` expects `flow` (in the URL query) and `email` (in the body) to be sent and works with API- and Browser-initiated flows. For API clients and Browser clients with HTTP Header `Accept: application/json` it either returns a HTTP 200 OK when the form is valid and HTTP 400 OK when the form is invalid and a HTTP 303 See Other redirect with a fresh verification flow if the flow was otherwise invalid (e.g. expired). For Browser clients without HTTP Header `Accept` or with `Accept: text/_*` it returns a HTTP 303 See Other redirect to the Verification UI URL with the Verification Flow ID appended. `sent_email` is the success state after `choose_method` when using the `link` method and allows the user to request another verification email. It works for both API and Browser-initiated flows and returns the same responses as the flow in `choose_method` state. `passed_challenge` expects a `token` to be sent in the URL query and given the nature of the flow (\"sending a verification link\") does not have any API capabilities. The server responds with a HTTP 303 See Other redirect either to the Settings UI URL (if the link was valid) and instructs the user to update their password, or a redirect to the Verification UI URL with a new Verification Flow ID which contains an error message that the verification link was invalid.  More information can be found at [Ory Kratos Email and Phone Verification Documentation](https://www.ory.com/docs/kratos/self-service/flows/verify-email-account-activation).
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class UpdateVerificationFlowExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IFrontendApi>();
+            string flow = default!; // The Verification Flow ID  The value for this parameter comes from `flow` URL Query parameter sent to your application (e.g. `/verification?flow=abcde`).
+            ClientUpdateVerificationFlowBody clientUpdateVerificationFlowBody = default!; // 
+            Option<string> token = default!; // Verification Token  The verification token which completes the verification request. If the token is invalid (e.g. expired) an error will be shown to the end-user.  This parameter is usually set in a link and not used by any direct API call. (optional)
+            Option<string> cookie = default!; // HTTP Cookies  When using the SDK in a browser app, on the server side you must include the HTTP Cookie Header sent by the client to your server here. This ensures that CSRF and session cookies are respected. (optional)
+            var response = await api.UpdateVerificationFlowAsync(flow, clientUpdateVerificationFlowBody, token, cookie);
+            ClientVerificationFlow? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
 | **flow** | **string** | The Verification Flow ID  The value for this parameter comes from &#x60;flow&#x60; URL Query parameter sent to your application (e.g. &#x60;/verification?flow&#x3D;abcde&#x60;). |  |
-| **clientUpdateVerificationFlowBody** | [**ClientUpdateVerificationFlowBody**](ClientUpdateVerificationFlowBody.md) |  |  |
+| **clientUpdateVerificationFlowBody** | [**ClientUpdateVerificationFlowBody**](../models/ClientUpdateVerificationFlowBody.md) |  |  |
 | **token** | **string** | Verification Token  The verification token which completes the verification request. If the token is invalid (e.g. expired) an error will be shown to the end-user.  This parameter is usually set in a link and not used by any direct API call. | [optional]  |
 | **cookie** | **string** | HTTP Cookies  When using the SDK in a browser app, on the server side you must include the HTTP Cookie Header sent by the client to your server here. This ensures that CSRF and session cookies are respected. | [optional]  |
 
 ### Return type
 
-[**ClientVerificationFlow**](ClientVerificationFlow.md)
+[**ClientVerificationFlow**](../models/ClientVerificationFlow.md)
 
 ### Authorization
 

--- a/clients/client/dotnet/docs/apis/IdentityApi.md
+++ b/clients/client/dotnet/docs/apis/IdentityApi.md
@@ -28,26 +28,60 @@ All URIs are relative to *https://playground.projects.oryapis.com*
 
 <a id="batchpatchidentities"></a>
 # **BatchPatchIdentities**
-> ClientBatchPatchIdentitiesResponse BatchPatchIdentities (ClientPatchIdentitiesBody clientPatchIdentitiesBody = null)
+> Task&lt;IBatchPatchIdentitiesApiResponse&gt; BatchPatchIdentitiesAsync(Option<ClientPatchIdentitiesBody> clientPatchIdentitiesBody = default, System.Threading.CancellationToken cancellationToken = default)
 
 Create multiple identities
 
 Creates multiple [identities](https://www.ory.com/docs/kratos/concepts/identity-user-model).  You can also use this endpoint to [import credentials](https://www.ory.com/docs/kratos/manage-identities/import-user-accounts-identities), including passwords, social sign-in settings, and multi-factor authentication methods.  If the patch includes hashed passwords you can import up to 1,000 identities per request.  If the patch includes at least one plaintext password you can import up to 200 identities per request.  Avoid importing large batches with plaintext passwords. They can cause timeouts as the passwords need to be hashed before they are stored.  If at least one identity is imported successfully, the response status is 200 OK. If all imports fail, the response is one of the following 4xx errors: 400 Bad Request: The request payload is invalid or improperly formatted. 409 Conflict: Duplicate identities or conflicting data were detected.  If you get a 504 Gateway Timeout: Reduce the batch size Avoid duplicate identities Pre-hash passwords with BCrypt  If the issue persists, contact support.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class BatchPatchIdentitiesExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IIdentityApi>();
+            Option<ClientPatchIdentitiesBody> clientPatchIdentitiesBody = default!; //  (optional)
+            var response = await api.BatchPatchIdentitiesAsync(clientPatchIdentitiesBody);
+            ClientBatchPatchIdentitiesResponse? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **clientPatchIdentitiesBody** | [**ClientPatchIdentitiesBody**](ClientPatchIdentitiesBody.md) |  | [optional]  |
+| **clientPatchIdentitiesBody** | [**ClientPatchIdentitiesBody**](../models/ClientPatchIdentitiesBody.md) |  | [optional]  |
 
 ### Return type
 
-[**ClientBatchPatchIdentitiesResponse**](ClientBatchPatchIdentitiesResponse.md)
+[**ClientBatchPatchIdentitiesResponse**](../models/ClientBatchPatchIdentitiesResponse.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -67,26 +101,60 @@ Creates multiple [identities](https://www.ory.com/docs/kratos/concepts/identity-
 
 <a id="createidentity"></a>
 # **CreateIdentity**
-> ClientIdentity CreateIdentity (ClientCreateIdentityBody clientCreateIdentityBody = null)
+> Task&lt;ICreateIdentityApiResponse&gt; CreateIdentityAsync(Option<ClientCreateIdentityBody> clientCreateIdentityBody = default, System.Threading.CancellationToken cancellationToken = default)
 
 Create an Identity
 
 Create an [identity](https://www.ory.com/docs/kratos/concepts/identity-user-model).  This endpoint can also be used to [import credentials](https://www.ory.com/docs/kratos/manage-identities/import-user-accounts-identities) for instance passwords, social sign in configurations, or multifactor methods.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class CreateIdentityExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IIdentityApi>();
+            Option<ClientCreateIdentityBody> clientCreateIdentityBody = default!; //  (optional)
+            var response = await api.CreateIdentityAsync(clientCreateIdentityBody);
+            ClientIdentity? model = response.Created();
+        }
+    }
+}
+```
 
 ### Parameters
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **clientCreateIdentityBody** | [**ClientCreateIdentityBody**](ClientCreateIdentityBody.md) |  | [optional]  |
+| **clientCreateIdentityBody** | [**ClientCreateIdentityBody**](../models/ClientCreateIdentityBody.md) |  | [optional]  |
 
 ### Return type
 
-[**ClientIdentity**](ClientIdentity.md)
+[**ClientIdentity**](../models/ClientIdentity.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -106,26 +174,60 @@ Create an [identity](https://www.ory.com/docs/kratos/concepts/identity-user-mode
 
 <a id="createrecoverycodeforidentity"></a>
 # **CreateRecoveryCodeForIdentity**
-> ClientRecoveryCodeForIdentity CreateRecoveryCodeForIdentity (ClientCreateRecoveryCodeForIdentityBody clientCreateRecoveryCodeForIdentityBody = null)
+> Task&lt;ICreateRecoveryCodeForIdentityApiResponse&gt; CreateRecoveryCodeForIdentityAsync(Option<ClientCreateRecoveryCodeForIdentityBody> clientCreateRecoveryCodeForIdentityBody = default, System.Threading.CancellationToken cancellationToken = default)
 
 Create a Recovery Code
 
 This endpoint creates a recovery code which should be given to the user in order for them to recover (or activate) their account.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class CreateRecoveryCodeForIdentityExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IIdentityApi>();
+            Option<ClientCreateRecoveryCodeForIdentityBody> clientCreateRecoveryCodeForIdentityBody = default!; //  (optional)
+            var response = await api.CreateRecoveryCodeForIdentityAsync(clientCreateRecoveryCodeForIdentityBody);
+            ClientRecoveryCodeForIdentity? model = response.Created();
+        }
+    }
+}
+```
 
 ### Parameters
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **clientCreateRecoveryCodeForIdentityBody** | [**ClientCreateRecoveryCodeForIdentityBody**](ClientCreateRecoveryCodeForIdentityBody.md) |  | [optional]  |
+| **clientCreateRecoveryCodeForIdentityBody** | [**ClientCreateRecoveryCodeForIdentityBody**](../models/ClientCreateRecoveryCodeForIdentityBody.md) |  | [optional]  |
 
 ### Return type
 
-[**ClientRecoveryCodeForIdentity**](ClientRecoveryCodeForIdentity.md)
+[**ClientRecoveryCodeForIdentity**](../models/ClientRecoveryCodeForIdentity.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -145,27 +247,62 @@ This endpoint creates a recovery code which should be given to the user in order
 
 <a id="createrecoverylinkforidentity"></a>
 # **CreateRecoveryLinkForIdentity**
-> ClientRecoveryLinkForIdentity CreateRecoveryLinkForIdentity (string returnTo = null, ClientCreateRecoveryLinkForIdentityBody clientCreateRecoveryLinkForIdentityBody = null)
+> Task&lt;ICreateRecoveryLinkForIdentityApiResponse&gt; CreateRecoveryLinkForIdentityAsync(Option<string> returnTo = default, Option<ClientCreateRecoveryLinkForIdentityBody> clientCreateRecoveryLinkForIdentityBody = default, System.Threading.CancellationToken cancellationToken = default)
 
 Create a Recovery Link
 
 This endpoint creates a recovery link which should be given to the user in order for them to recover (or activate) their account.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class CreateRecoveryLinkForIdentityExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IIdentityApi>();
+            Option<string> returnTo = default!; //  (optional)
+            Option<ClientCreateRecoveryLinkForIdentityBody> clientCreateRecoveryLinkForIdentityBody = default!; //  (optional)
+            var response = await api.CreateRecoveryLinkForIdentityAsync(returnTo, clientCreateRecoveryLinkForIdentityBody);
+            ClientRecoveryLinkForIdentity? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
 | **returnTo** | **string** |  | [optional]  |
-| **clientCreateRecoveryLinkForIdentityBody** | [**ClientCreateRecoveryLinkForIdentityBody**](ClientCreateRecoveryLinkForIdentityBody.md) |  | [optional]  |
+| **clientCreateRecoveryLinkForIdentityBody** | [**ClientCreateRecoveryLinkForIdentityBody**](../models/ClientCreateRecoveryLinkForIdentityBody.md) |  | [optional]  |
 
 ### Return type
 
-[**ClientRecoveryLinkForIdentity**](ClientRecoveryLinkForIdentity.md)
+[**ClientRecoveryLinkForIdentity**](../models/ClientRecoveryLinkForIdentity.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -185,26 +322,60 @@ This endpoint creates a recovery link which should be given to the user in order
 
 <a id="createtestloginflow"></a>
 # **CreateTestLoginFlow**
-> ClientLoginFlow CreateTestLoginFlow (ClientCreateTestLoginFlowBody clientCreateTestLoginFlowBody)
+> Task&lt;ICreateTestLoginFlowApiResponse&gt; CreateTestLoginFlowAsync(ClientCreateTestLoginFlowBody clientCreateTestLoginFlowBody, System.Threading.CancellationToken cancellationToken = default)
 
 Create a test OIDC login flow
 
 Creates a dry-run OIDC test login flow pre-scoped to one provider. The returned flow carries a single-submit UI and a CSRF bearer token. No identity is persisted and no session is issued when the flow completes; the captured debug data is returned in the flow's test_context.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class CreateTestLoginFlowExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IIdentityApi>();
+            ClientCreateTestLoginFlowBody clientCreateTestLoginFlowBody = default!; // 
+            var response = await api.CreateTestLoginFlowAsync(clientCreateTestLoginFlowBody);
+            ClientLoginFlow? model = response.Created();
+        }
+    }
+}
+```
 
 ### Parameters
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **clientCreateTestLoginFlowBody** | [**ClientCreateTestLoginFlowBody**](ClientCreateTestLoginFlowBody.md) |  |  |
+| **clientCreateTestLoginFlowBody** | [**ClientCreateTestLoginFlowBody**](../models/ClientCreateTestLoginFlowBody.md) |  |  |
 
 ### Return type
 
-[**ClientLoginFlow**](ClientLoginFlow.md)
+[**ClientLoginFlow**](../models/ClientLoginFlow.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -224,12 +395,45 @@ Creates a dry-run OIDC test login flow pre-scoped to one provider. The returned 
 
 <a id="deleteidentity"></a>
 # **DeleteIdentity**
-> void DeleteIdentity (string id)
+> Task&lt;IDeleteIdentityApiResponse&gt; DeleteIdentityAsync(string id, System.Threading.CancellationToken cancellationToken = default)
 
 Delete an Identity
 
 Calling this endpoint irrecoverably and permanently deletes the [identity](https://www.ory.com/docs/kratos/concepts/identity-user-model) given its ID. This action can not be undone. This endpoint returns 204 when the identity was deleted or 404 if the identity was not found.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class DeleteIdentityExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IIdentityApi>();
+            string id = default!; // ID is the identity's ID.
+            await api.DeleteIdentityAsync(id);
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -243,7 +447,7 @@ void (empty response body)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -262,12 +466,47 @@ void (empty response body)
 
 <a id="deleteidentitycredentials"></a>
 # **DeleteIdentityCredentials**
-> void DeleteIdentityCredentials (string id, string type, string identifier = null)
+> Task&lt;IDeleteIdentityCredentialsApiResponse&gt; DeleteIdentityCredentialsAsync(string id, string type, Option<string> identifier = default, System.Threading.CancellationToken cancellationToken = default)
 
 Delete a credential for a specific identity
 
 Delete an [identity](https://www.ory.com/docs/kratos/concepts/identity-user-model) credential by its type. You cannot delete passkeys or code auth credentials through this API.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class DeleteIdentityCredentialsExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IIdentityApi>();
+            string id = default!; // ID is the identity's ID.
+            string type = default!; // Type is the type of credentials to delete. password CredentialsTypePassword oidc CredentialsTypeOIDC totp CredentialsTypeTOTP lookup_secret CredentialsTypeLookup webauthn CredentialsTypeWebAuthn code CredentialsTypeCodeAuth passkey CredentialsTypePasskey profile CredentialsTypeProfile saml CredentialsTypeSAML deviceauthn CredentialsTypeDeviceAuthn identifier_first CredentialsTypeIdentifierFirst link_recovery CredentialsTypeRecoveryLink  CredentialsTypeRecoveryLink is a special credential type linked to the link strategy (recovery flow).  It is not used within the credentials object itself. code_recovery CredentialsTypeRecoveryCode
+            Option<string> identifier = default!; // Identifier is the identifier of the credential to delete. It is required for the `oidc`, `saml`, and `deviceauthn` credential types: for `oidc` and `saml` it selects the provider link to remove, for `deviceauthn` it is the `client_key_id` of the device key to revoke. Find the identifier by calling the `GET /admin/identities/{id}?include_credential={type}` endpoint. (optional)
+            await api.DeleteIdentityCredentialsAsync(id, type, identifier);
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -283,7 +522,7 @@ void (empty response body)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -303,12 +542,45 @@ void (empty response body)
 
 <a id="deleteidentitysessions"></a>
 # **DeleteIdentitySessions**
-> void DeleteIdentitySessions (string id)
+> Task&lt;IDeleteIdentitySessionsApiResponse&gt; DeleteIdentitySessionsAsync(string id, System.Threading.CancellationToken cancellationToken = default)
 
 Delete & Invalidate an Identity's Sessions
 
 Calling this endpoint irrecoverably and permanently deletes and invalidates all sessions that belong to the given Identity.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class DeleteIdentitySessionsExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IIdentityApi>();
+            string id = default!; // ID is the identity's ID.
+            await api.DeleteIdentitySessionsAsync(id);
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -322,7 +594,7 @@ void (empty response body)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -343,12 +615,45 @@ void (empty response body)
 
 <a id="disablesession"></a>
 # **DisableSession**
-> void DisableSession (string id)
+> Task&lt;IDisableSessionApiResponse&gt; DisableSessionAsync(string id, System.Threading.CancellationToken cancellationToken = default)
 
 Deactivate a Session
 
 Calling this endpoint deactivates the specified session. Session data is not deleted.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class DisableSessionExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IIdentityApi>();
+            string id = default!; // ID is the session's ID.
+            await api.DisableSessionAsync(id);
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -362,7 +667,7 @@ void (empty response body)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -382,12 +687,46 @@ void (empty response body)
 
 <a id="extendsession"></a>
 # **ExtendSession**
-> ClientSession ExtendSession (string id)
+> Task&lt;IExtendSessionApiResponse&gt; ExtendSessionAsync(string id, System.Threading.CancellationToken cancellationToken = default)
 
 Extend a Session
 
 Calling this endpoint extends the given session ID. If `session.earliest_possible_extend` is set it will only extend the session after the specified time has passed.  This endpoint returns per default a 204 No Content response on success. Older Ory Network projects may return a 200 OK response with the session in the body. Returning the session as part of the response will be deprecated in the future and should not be relied upon.  This endpoint ignores consecutive requests to extend the same session and returns a 404 error in those scenarios. This endpoint also returns 404 errors if the session does not exist.  Retrieve the session ID from the `/sessions/whoami` endpoint / `toSession` SDK method.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class ExtendSessionExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IIdentityApi>();
+            string id = default!; // ID is the session's ID.
+            var response = await api.ExtendSessionAsync(id);
+            ClientSession? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -397,11 +736,11 @@ Calling this endpoint extends the given session ID. If `session.earliest_possibl
 
 ### Return type
 
-[**ClientSession**](ClientSession.md)
+[**ClientSession**](../models/ClientSession.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -422,27 +761,62 @@ Calling this endpoint extends the given session ID. If `session.earliest_possibl
 
 <a id="getidentity"></a>
 # **GetIdentity**
-> ClientIdentity GetIdentity (string id, List<string> includeCredential = null)
+> Task&lt;IGetIdentityApiResponse&gt; GetIdentityAsync(string id, Option<List<string>> includeCredential = default, System.Threading.CancellationToken cancellationToken = default)
 
 Get an Identity
 
 Return an [identity](https://www.ory.com/docs/kratos/concepts/identity-user-model) by its ID. You can optionally include credentials (e.g. social sign in connections) in the response by using the `include_credential` query parameter.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class GetIdentityExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IIdentityApi>();
+            string id = default!; // ID must be set to the ID of identity you want to get
+            Option<List<string>> includeCredential = default!; // Include Credentials in Response  Include any credential, for example `password` or `oidc`, in the response. When set to `oidc`, This will return the initial OAuth 2.0 Access Token, OAuth 2.0 Refresh Token, and the OpenID Connect ID Token if available. (optional)
+            var response = await api.GetIdentityAsync(id, includeCredential);
+            ClientIdentity? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
 | **id** | **string** | ID must be set to the ID of identity you want to get |  |
-| **includeCredential** | [**List&lt;string&gt;**](string.md) | Include Credentials in Response  Include any credential, for example &#x60;password&#x60; or &#x60;oidc&#x60;, in the response. When set to &#x60;oidc&#x60;, This will return the initial OAuth 2.0 Access Token, OAuth 2.0 Refresh Token, and the OpenID Connect ID Token if available. | [optional]  |
+| **includeCredential** | [**List&lt;string&gt;**](../models/string.md) | Include Credentials in Response  Include any credential, for example &#x60;password&#x60; or &#x60;oidc&#x60;, in the response. When set to &#x60;oidc&#x60;, This will return the initial OAuth 2.0 Access Token, OAuth 2.0 Refresh Token, and the OpenID Connect ID Token if available. | [optional]  |
 
 ### Return type
 
-[**ClientIdentity**](ClientIdentity.md)
+[**ClientIdentity**](../models/ClientIdentity.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -461,27 +835,62 @@ Return an [identity](https://www.ory.com/docs/kratos/concepts/identity-user-mode
 
 <a id="getidentitybyexternalid"></a>
 # **GetIdentityByExternalID**
-> ClientIdentity GetIdentityByExternalID (string externalID, List<string> includeCredential = null)
+> Task&lt;IGetIdentityByExternalIDApiResponse&gt; GetIdentityByExternalIDAsync(string externalID, Option<List<string>> includeCredential = default, System.Threading.CancellationToken cancellationToken = default)
 
 Get an Identity by its External ID
 
 Return an [identity](https://www.ory.com/docs/kratos/concepts/identity-user-model) by its external ID. You can optionally include credentials (e.g. social sign in connections) in the response by using the `include_credential` query parameter.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class GetIdentityByExternalIDExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IIdentityApi>();
+            string externalID = default!; // ExternalID must be set to the ID of identity you want to get
+            Option<List<string>> includeCredential = default!; // Include Credentials in Response  Include any credential, for example `password` or `oidc`, in the response. When set to `oidc`, This will return the initial OAuth 2.0 Access Token, OAuth 2.0 Refresh Token, and the OpenID Connect ID Token if available. (optional)
+            var response = await api.GetIdentityByExternalIDAsync(externalID, includeCredential);
+            ClientIdentity? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
 | **externalID** | **string** | ExternalID must be set to the ID of identity you want to get |  |
-| **includeCredential** | [**List&lt;string&gt;**](string.md) | Include Credentials in Response  Include any credential, for example &#x60;password&#x60; or &#x60;oidc&#x60;, in the response. When set to &#x60;oidc&#x60;, This will return the initial OAuth 2.0 Access Token, OAuth 2.0 Refresh Token, and the OpenID Connect ID Token if available. | [optional]  |
+| **includeCredential** | [**List&lt;string&gt;**](../models/string.md) | Include Credentials in Response  Include any credential, for example &#x60;password&#x60; or &#x60;oidc&#x60;, in the response. When set to &#x60;oidc&#x60;, This will return the initial OAuth 2.0 Access Token, OAuth 2.0 Refresh Token, and the OpenID Connect ID Token if available. | [optional]  |
 
 ### Return type
 
-[**ClientIdentity**](ClientIdentity.md)
+[**ClientIdentity**](../models/ClientIdentity.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -500,12 +909,44 @@ Return an [identity](https://www.ory.com/docs/kratos/concepts/identity-user-mode
 
 <a id="getidentityschema"></a>
 # **GetIdentitySchema**
-> Object GetIdentitySchema (string id)
+> Task&lt;IGetIdentitySchemaApiResponse&gt; GetIdentitySchemaAsync(string id, System.Threading.CancellationToken cancellationToken = default)
 
 Get Identity JSON Schema
 
 Return a specific identity schema.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class GetIdentitySchemaExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IIdentityApi>();
+            string id = default!; // ID must be set to the ID of schema you want to get
+            var response = await api.GetIdentitySchemaAsync(id);
+            Object? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -538,27 +979,62 @@ No authorization required
 
 <a id="getsession"></a>
 # **GetSession**
-> ClientSession GetSession (string id, List<string> expand = null)
+> Task&lt;IGetSessionApiResponse&gt; GetSessionAsync(string id, Option<List<string>> expand = default, System.Threading.CancellationToken cancellationToken = default)
 
 Get Session
 
 This endpoint is useful for:  Getting a session object with all specified expandables that exist in an administrative context.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class GetSessionExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IIdentityApi>();
+            string id = default!; // ID is the session's ID.
+            Option<List<string>> expand = default!; // ExpandOptions is a query parameter encoded list of all properties that must be expanded in the Session. Example - ?expand=Identity&expand=Devices If no value is provided, the expandable properties are skipped. (optional)
+            var response = await api.GetSessionAsync(id, expand);
+            ClientSession? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
 | **id** | **string** | ID is the session&#39;s ID. |  |
-| **expand** | [**List&lt;string&gt;**](string.md) | ExpandOptions is a query parameter encoded list of all properties that must be expanded in the Session. Example - ?expand&#x3D;Identity&amp;expand&#x3D;Devices If no value is provided, the expandable properties are skipped. | [optional]  |
+| **expand** | [**List&lt;string&gt;**](../models/string.md) | ExpandOptions is a query parameter encoded list of all properties that must be expanded in the Session. Example - ?expand&#x3D;Identity&amp;expand&#x3D;Devices If no value is provided, the expandable properties are skipped. | [optional]  |
 
 ### Return type
 
-[**ClientSession**](ClientSession.md)
+[**ClientSession**](../models/ClientSession.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -577,12 +1053,55 @@ This endpoint is useful for:  Getting a session object with all specified expand
 
 <a id="listidentities"></a>
 # **ListIdentities**
-> List&lt;ClientIdentity&gt; ListIdentities (long perPage = null, long page = null, long pageSize = null, string pageToken = null, string consistency = null, List<string> ids = null, string credentialsIdentifier = null, string previewCredentialsIdentifierSimilar = null, List<string> includeCredential = null, string organizationId = null)
+> Task&lt;IListIdentitiesApiResponse&gt; ListIdentitiesAsync(Option<long> perPage = default, Option<long> page = default, Option<long> pageSize = default, Option<string> pageToken = default, Option<string> consistency = default, Option<List<string>> ids = default, Option<string> credentialsIdentifier = default, Option<string> previewCredentialsIdentifierSimilar = default, Option<List<string>> includeCredential = default, Option<string> organizationId = default, System.Threading.CancellationToken cancellationToken = default)
 
 List Identities
 
 Lists all [identities](https://www.ory.com/docs/kratos/concepts/identity-user-model) in the system. Note: filters cannot be combined.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class ListIdentitiesExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IIdentityApi>();
+            Option<long> perPage = default!; // Deprecated Items per Page  DEPRECATED: Please use `page_token` instead. This parameter will be removed in the future.  This is the number of items per page. (optional)
+            Option<long> page = default!; // Deprecated Pagination Page  DEPRECATED: Please use `page_token` instead. This parameter will be removed in the future.  This value is currently an integer, but it is not sequential. The value is not the page number, but a reference. The next page can be any number and some numbers might return an empty list.  For example, page 2 might not follow after page 1. And even if page 3 and 5 exist, but page 4 might not exist. The first page can be retrieved by omitting this parameter. Following page pointers will be returned in the `Link` header. (optional)
+            Option<long> pageSize = default!; // Page Size  This is the number of items per page to return. For details on pagination please head over to the [pagination documentation](https://www.ory.com/docs/ecosystem/api-design#pagination). (optional)
+            Option<string> pageToken = default!; // Next Page Token  The next page token. For details on pagination please head over to the [pagination documentation](https://www.ory.com/docs/ecosystem/api-design#pagination). (optional)
+            Option<string> consistency = default!; // Read Consistency Level (preview)  The read consistency level determines the consistency guarantee for reads:  strong (slow): The read is guaranteed to return the most recent data committed at the start of the read. eventual (very fast): The result will return data that is about 4.8 seconds old.  The default consistency guarantee can be changed in the Ory Network Console or using the Ory CLI with `ory patch project - -replace '/previews/default_read_consistency_level=\"strong\"'`.  Setting the default consistency level to `eventual` may cause regressions in the future as we add consistency controls to more APIs. Currently, the following APIs will be affected by this setting:  `GET /admin/identities`  This feature is in preview and only available in Ory Network.  ConsistencyLevelUnset  ConsistencyLevelUnset is the unset / default consistency level. strong ConsistencyLevelStrong  ConsistencyLevelStrong is the strong consistency level. eventual ConsistencyLevelEventual  ConsistencyLevelEventual is the eventual consistency level using follower read timestamps. (optional)
+            Option<List<string>> ids = default!; // Retrieve multiple identities by their IDs.  This parameter has the following limitations:  Duplicate or non-existent IDs are ignored. The order of returned IDs may be different from the request. This filter does not support pagination. You must implement your own pagination as the maximum number of items returned by this endpoint may not exceed a certain threshold (currently 500). (optional)
+            Option<string> credentialsIdentifier = default!; // CredentialsIdentifier is the identifier (username, email) of the credentials to look up using exact match. Only one of CredentialsIdentifier and CredentialsIdentifierSimilar can be used. (optional)
+            Option<string> previewCredentialsIdentifierSimilar = default!; // This is an EXPERIMENTAL parameter that WILL CHANGE. Do NOT rely on consistent, deterministic behavior. THIS PARAMETER WILL BE REMOVED IN AN UPCOMING RELEASE WITHOUT ANY MIGRATION PATH.  CredentialsIdentifierSimilar is the (partial) identifier (username, email) of the credentials to look up using similarity search. Only one of CredentialsIdentifier and CredentialsIdentifierSimilar can be used. (optional)
+            Option<List<string>> includeCredential = default!; // Include Credentials in Response  Include any credential, for example `password` or `oidc`, in the response. When set to `oidc`, This will return the initial OAuth 2.0 Access Token, OAuth 2.0 Refresh Token, and the OpenID Connect ID Token if available. (optional)
+            Option<string> organizationId = default!; // List identities that belong to a specific organization. (optional)
+            var response = await api.ListIdentitiesAsync(perPage, page, pageSize, pageToken, consistency, ids, credentialsIdentifier, previewCredentialsIdentifierSimilar, includeCredential, organizationId);
+            List<ClientIdentity>? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -593,19 +1112,19 @@ Lists all [identities](https://www.ory.com/docs/kratos/concepts/identity-user-mo
 | **pageSize** | **long** | Page Size  This is the number of items per page to return. For details on pagination please head over to the [pagination documentation](https://www.ory.com/docs/ecosystem/api-design#pagination). | [optional] [default to 250] |
 | **pageToken** | **string** | Next Page Token  The next page token. For details on pagination please head over to the [pagination documentation](https://www.ory.com/docs/ecosystem/api-design#pagination). | [optional]  |
 | **consistency** | **string** | Read Consistency Level (preview)  The read consistency level determines the consistency guarantee for reads:  strong (slow): The read is guaranteed to return the most recent data committed at the start of the read. eventual (very fast): The result will return data that is about 4.8 seconds old.  The default consistency guarantee can be changed in the Ory Network Console or using the Ory CLI with &#x60;ory patch project - -replace &#39;/previews/default_read_consistency_level&#x3D;\&quot;strong\&quot;&#39;&#x60;.  Setting the default consistency level to &#x60;eventual&#x60; may cause regressions in the future as we add consistency controls to more APIs. Currently, the following APIs will be affected by this setting:  &#x60;GET /admin/identities&#x60;  This feature is in preview and only available in Ory Network.  ConsistencyLevelUnset  ConsistencyLevelUnset is the unset / default consistency level. strong ConsistencyLevelStrong  ConsistencyLevelStrong is the strong consistency level. eventual ConsistencyLevelEventual  ConsistencyLevelEventual is the eventual consistency level using follower read timestamps. | [optional]  |
-| **ids** | [**List&lt;string&gt;**](string.md) | Retrieve multiple identities by their IDs.  This parameter has the following limitations:  Duplicate or non-existent IDs are ignored. The order of returned IDs may be different from the request. This filter does not support pagination. You must implement your own pagination as the maximum number of items returned by this endpoint may not exceed a certain threshold (currently 500). | [optional]  |
+| **ids** | [**List&lt;string&gt;**](../models/string.md) | Retrieve multiple identities by their IDs.  This parameter has the following limitations:  Duplicate or non-existent IDs are ignored. The order of returned IDs may be different from the request. This filter does not support pagination. You must implement your own pagination as the maximum number of items returned by this endpoint may not exceed a certain threshold (currently 500). | [optional]  |
 | **credentialsIdentifier** | **string** | CredentialsIdentifier is the identifier (username, email) of the credentials to look up using exact match. Only one of CredentialsIdentifier and CredentialsIdentifierSimilar can be used. | [optional]  |
 | **previewCredentialsIdentifierSimilar** | **string** | This is an EXPERIMENTAL parameter that WILL CHANGE. Do NOT rely on consistent, deterministic behavior. THIS PARAMETER WILL BE REMOVED IN AN UPCOMING RELEASE WITHOUT ANY MIGRATION PATH.  CredentialsIdentifierSimilar is the (partial) identifier (username, email) of the credentials to look up using similarity search. Only one of CredentialsIdentifier and CredentialsIdentifierSimilar can be used. | [optional]  |
-| **includeCredential** | [**List&lt;string&gt;**](string.md) | Include Credentials in Response  Include any credential, for example &#x60;password&#x60; or &#x60;oidc&#x60;, in the response. When set to &#x60;oidc&#x60;, This will return the initial OAuth 2.0 Access Token, OAuth 2.0 Refresh Token, and the OpenID Connect ID Token if available. | [optional]  |
+| **includeCredential** | [**List&lt;string&gt;**](../models/string.md) | Include Credentials in Response  Include any credential, for example &#x60;password&#x60; or &#x60;oidc&#x60;, in the response. When set to &#x60;oidc&#x60;, This will return the initial OAuth 2.0 Access Token, OAuth 2.0 Refresh Token, and the OpenID Connect ID Token if available. | [optional]  |
 | **organizationId** | **string** | List identities that belong to a specific organization. | [optional]  |
 
 ### Return type
 
-[**List&lt;ClientIdentity&gt;**](ClientIdentity.md)
+[**List&lt;ClientIdentity&gt;**](../models/ClientIdentity.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -623,12 +1142,47 @@ Lists all [identities](https://www.ory.com/docs/kratos/concepts/identity-user-mo
 
 <a id="listidentityschemas"></a>
 # **ListIdentitySchemas**
-> List&lt;ClientIdentitySchemaContainer&gt; ListIdentitySchemas (long perPage = null, long page = null, long pageSize = null, string pageToken = null)
+> Task&lt;IListIdentitySchemasApiResponse&gt; ListIdentitySchemasAsync(Option<long> perPage = default, Option<long> page = default, Option<long> pageSize = default, Option<string> pageToken = default, System.Threading.CancellationToken cancellationToken = default)
 
 Get all Identity Schemas
 
 Returns a list of all identity schemas currently in use.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class ListIdentitySchemasExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IIdentityApi>();
+            Option<long> perPage = default!; // Deprecated Items per Page  DEPRECATED: Please use `page_token` instead. This parameter will be removed in the future.  This is the number of items per page. (optional)
+            Option<long> page = default!; // Deprecated Pagination Page  DEPRECATED: Please use `page_token` instead. This parameter will be removed in the future.  This value is currently an integer, but it is not sequential. The value is not the page number, but a reference. The next page can be any number and some numbers might return an empty list.  For example, page 2 might not follow after page 1. And even if page 3 and 5 exist, but page 4 might not exist. The first page can be retrieved by omitting this parameter. Following page pointers will be returned in the `Link` header. (optional)
+            Option<long> pageSize = default!; // Page Size  This is the number of items per page to return. For details on pagination please head over to the [pagination documentation](https://www.ory.com/docs/ecosystem/api-design#pagination). (optional)
+            Option<string> pageToken = default!; // Next Page Token  The next page token. For details on pagination please head over to the [pagination documentation](https://www.ory.com/docs/ecosystem/api-design#pagination). (optional)
+            var response = await api.ListIdentitySchemasAsync(perPage, page, pageSize, pageToken);
+            List<ClientIdentitySchemaContainer>? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -641,7 +1195,7 @@ Returns a list of all identity schemas currently in use.
 
 ### Return type
 
-[**List&lt;ClientIdentitySchemaContainer&gt;**](ClientIdentitySchemaContainer.md)
+[**List&lt;ClientIdentitySchemaContainer&gt;**](../models/ClientIdentitySchemaContainer.md)
 
 ### Authorization
 
@@ -663,12 +1217,51 @@ No authorization required
 
 <a id="listidentitysessions"></a>
 # **ListIdentitySessions**
-> List&lt;ClientSession&gt; ListIdentitySessions (string id, long perPage = null, long page = null, long pageSize = null, string pageToken = null, bool active = null)
+> Task&lt;IListIdentitySessionsApiResponse&gt; ListIdentitySessionsAsync(string id, Option<long> perPage = default, Option<long> page = default, Option<long> pageSize = default, Option<string> pageToken = default, Option<bool> active = default, System.Threading.CancellationToken cancellationToken = default)
 
 List an Identity's Sessions
 
 This endpoint returns all sessions that belong to the given Identity.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class ListIdentitySessionsExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IIdentityApi>();
+            string id = default!; // ID is the identity's ID.
+            Option<long> perPage = default!; // Deprecated Items per Page  DEPRECATED: Please use `page_token` instead. This parameter will be removed in the future.  This is the number of items per page. (optional)
+            Option<long> page = default!; // Deprecated Pagination Page  DEPRECATED: Please use `page_token` instead. This parameter will be removed in the future.  This value is currently an integer, but it is not sequential. The value is not the page number, but a reference. The next page can be any number and some numbers might return an empty list.  For example, page 2 might not follow after page 1. And even if page 3 and 5 exist, but page 4 might not exist. The first page can be retrieved by omitting this parameter. Following page pointers will be returned in the `Link` header. (optional)
+            Option<long> pageSize = default!; // Page Size  This is the number of items per page to return. For details on pagination please head over to the [pagination documentation](https://www.ory.com/docs/ecosystem/api-design#pagination). (optional)
+            Option<string> pageToken = default!; // Next Page Token  The next page token. For details on pagination please head over to the [pagination documentation](https://www.ory.com/docs/ecosystem/api-design#pagination). (optional)
+            Option<bool> active = default!; // Active is a boolean flag that filters out sessions based on the state. If no value is provided, all sessions are returned. (optional)
+            var response = await api.ListIdentitySessionsAsync(id, perPage, page, pageSize, pageToken, active);
+            List<ClientSession>? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -683,11 +1276,11 @@ This endpoint returns all sessions that belong to the given Identity.
 
 ### Return type
 
-[**List&lt;ClientSession&gt;**](ClientSession.md)
+[**List&lt;ClientSession&gt;**](../models/ClientSession.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -707,12 +1300,49 @@ This endpoint returns all sessions that belong to the given Identity.
 
 <a id="listsessions"></a>
 # **ListSessions**
-> List&lt;ClientSession&gt; ListSessions (long pageSize = null, string pageToken = null, bool active = null, List<string> expand = null)
+> Task&lt;IListSessionsApiResponse&gt; ListSessionsAsync(Option<long> pageSize = default, Option<string> pageToken = default, Option<bool> active = default, Option<List<string>> expand = default, System.Threading.CancellationToken cancellationToken = default)
 
 List All Sessions
 
 Listing all sessions that exist.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class ListSessionsExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IIdentityApi>();
+            Option<long> pageSize = default!; // Items per Page  This is the number of items per page to return. For details on pagination please head over to the [pagination documentation](https://www.ory.com/docs/ecosystem/api-design#pagination). (optional)
+            Option<string> pageToken = default!; // Next Page Token  The next page token. For details on pagination please head over to the [pagination documentation](https://www.ory.com/docs/ecosystem/api-design#pagination). (optional)
+            Option<bool> active = default!; // Active is a boolean flag that filters out sessions based on the state. If no value is provided, all sessions are returned. (optional)
+            Option<List<string>> expand = default!; // ExpandOptions is a query parameter encoded list of all properties that must be expanded in the Session. If no value is provided, the expandable properties are skipped. (optional)
+            var response = await api.ListSessionsAsync(pageSize, pageToken, active, expand);
+            List<ClientSession>? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -721,15 +1351,15 @@ Listing all sessions that exist.
 | **pageSize** | **long** | Items per Page  This is the number of items per page to return. For details on pagination please head over to the [pagination documentation](https://www.ory.com/docs/ecosystem/api-design#pagination). | [optional] [default to 250] |
 | **pageToken** | **string** | Next Page Token  The next page token. For details on pagination please head over to the [pagination documentation](https://www.ory.com/docs/ecosystem/api-design#pagination). | [optional]  |
 | **active** | **bool** | Active is a boolean flag that filters out sessions based on the state. If no value is provided, all sessions are returned. | [optional]  |
-| **expand** | [**List&lt;string&gt;**](string.md) | ExpandOptions is a query parameter encoded list of all properties that must be expanded in the Session. If no value is provided, the expandable properties are skipped. | [optional]  |
+| **expand** | [**List&lt;string&gt;**](../models/string.md) | ExpandOptions is a query parameter encoded list of all properties that must be expanded in the Session. If no value is provided, the expandable properties are skipped. | [optional]  |
 
 ### Return type
 
-[**List&lt;ClientSession&gt;**](ClientSession.md)
+[**List&lt;ClientSession&gt;**](../models/ClientSession.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -748,26 +1378,60 @@ Listing all sessions that exist.
 
 <a id="managesessions"></a>
 # **ManageSessions**
-> ClientManageSessionsResponse ManageSessions (ClientManageSessionsBody clientManageSessionsBody)
+> Task&lt;IManageSessionsApiResponse&gt; ManageSessionsAsync(ClientManageSessionsBody clientManageSessionsBody, System.Threading.CancellationToken cancellationToken = default)
 
 Manage sessions in bulk
 
 Disable or delete sessions for a list of identities or a list of sessions in a single call. The `action` field selects the operation:  `disable` — deactivate matching sessions (sets `active = false`, preserves audit data). `delete` — permanently delete matching sessions.  Exactly one of `identities` or `sessions` must be provided. To scope the operation to every session in the network, pass `identities: [\"*\"]`; the wildcard is not accepted in the `sessions` field. Up to 500 explicit IDs are accepted per call.  All requests return `200 OK` with `{processed, more}`. `processed` reports how many rows the call affected; for `disable` it counts only sessions that were active before the call. `more` is `true` only when a wildcard request reached the per-call batch limit and additional rows may remain; callers drain the network by re-issuing the same request while `more` is `true`. Explicit-IDs requests always return `more: false`.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class ManageSessionsExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IIdentityApi>();
+            ClientManageSessionsBody clientManageSessionsBody = default!; // 
+            var response = await api.ManageSessionsAsync(clientManageSessionsBody);
+            ClientManageSessionsResponse? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **clientManageSessionsBody** | [**ClientManageSessionsBody**](ClientManageSessionsBody.md) |  |  |
+| **clientManageSessionsBody** | [**ClientManageSessionsBody**](../models/ClientManageSessionsBody.md) |  |  |
 
 ### Return type
 
-[**ClientManageSessionsResponse**](ClientManageSessionsResponse.md)
+[**ClientManageSessionsResponse**](../models/ClientManageSessionsResponse.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -787,27 +1451,62 @@ Disable or delete sessions for a list of identities or a list of sessions in a s
 
 <a id="patchidentity"></a>
 # **PatchIdentity**
-> ClientIdentity PatchIdentity (string id, List<ClientJsonPatch> clientJsonPatch = null)
+> Task&lt;IPatchIdentityApiResponse&gt; PatchIdentityAsync(string id, Option<List<ClientJsonPatch>> clientJsonPatch = default, System.Threading.CancellationToken cancellationToken = default)
 
 Patch an Identity
 
 Partially updates an [identity's](https://www.ory.com/docs/kratos/concepts/identity-user-model) field using [JSON Patch](https://jsonpatch.com/). The fields `id`, `stateChangedAt` and `credentials` can not be updated using this method.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class PatchIdentityExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IIdentityApi>();
+            string id = default!; // ID must be set to the ID of identity you want to update
+            Option<List<ClientJsonPatch>> clientJsonPatch = default!; //  (optional)
+            var response = await api.PatchIdentityAsync(id, clientJsonPatch);
+            ClientIdentity? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
 | **id** | **string** | ID must be set to the ID of identity you want to update |  |
-| **clientJsonPatch** | [**List&lt;ClientJsonPatch&gt;**](ClientJsonPatch.md) |  | [optional]  |
+| **clientJsonPatch** | [**List&lt;ClientJsonPatch&gt;**](../models/ClientJsonPatch.md) |  | [optional]  |
 
 ### Return type
 
-[**ClientIdentity**](ClientIdentity.md)
+[**ClientIdentity**](../models/ClientIdentity.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -828,27 +1527,62 @@ Partially updates an [identity's](https://www.ory.com/docs/kratos/concepts/ident
 
 <a id="updateidentity"></a>
 # **UpdateIdentity**
-> ClientIdentity UpdateIdentity (string id, ClientUpdateIdentityBody clientUpdateIdentityBody = null)
+> Task&lt;IUpdateIdentityApiResponse&gt; UpdateIdentityAsync(string id, Option<ClientUpdateIdentityBody> clientUpdateIdentityBody = default, System.Threading.CancellationToken cancellationToken = default)
 
 Update an Identity
 
 This endpoint updates an [identity](https://www.ory.com/docs/kratos/concepts/identity-user-model). The full identity payload (except credentials) is expected.  It is possible to update the identity's credentials as well. Using this operation, credentials will not be overwritten but instead added to the list. For example, if a user has a social sign in connection set up, updating the credentials will keep the social sign in connection and add the new credentials to the list. This prevents accidentally overwriting credentials and locking out users. A complete view of all credential types is here:  `password`: The existing password credential will be completely replaced with the new configuration. You can provide either a hashed password, a plaintext password (which will be hashed), or enable the password migration hook. `oidc`, `saml`: The existing OIDC and SAML credentials will be kept and the new credentials will be added to the list. `totp`: The existing TOTP credentials will be replaced with the new configuration. `lookup_secret`: The existing Lookup Secret codes will be kept and the new codes will be added to the list. `webauthn`, `passkey`: The existing credentials are preserved, new credentials are added, and credentials with matching IDs are updated with new values. If a new `user_handle` is provided, it's added to the identity's identifiers list while preserving previous user handles. `code`: To import code credentials, configure your identity schema to use one of the identity traits as an identifier source (`{\"ory.sh/kratos\":{\"code\":{\"identifier\":true\", \"via\":\"email\"}}}`).
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class UpdateIdentityExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IIdentityApi>();
+            string id = default!; // ID must be set to the ID of identity you want to update
+            Option<ClientUpdateIdentityBody> clientUpdateIdentityBody = default!; //  (optional)
+            var response = await api.UpdateIdentityAsync(id, clientUpdateIdentityBody);
+            ClientIdentity? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
 | **id** | **string** | ID must be set to the ID of identity you want to update |  |
-| **clientUpdateIdentityBody** | [**ClientUpdateIdentityBody**](ClientUpdateIdentityBody.md) |  | [optional]  |
+| **clientUpdateIdentityBody** | [**ClientUpdateIdentityBody**](../models/ClientUpdateIdentityBody.md) |  | [optional]  |
 
 ### Return type
 
-[**ClientIdentity**](ClientIdentity.md)
+[**ClientIdentity**](../models/ClientIdentity.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 

--- a/clients/client/dotnet/docs/apis/JwkApi.md
+++ b/clients/client/dotnet/docs/apis/JwkApi.md
@@ -14,27 +14,62 @@ All URIs are relative to *https://playground.projects.oryapis.com*
 
 <a id="createjsonwebkeyset"></a>
 # **CreateJsonWebKeySet**
-> ClientJsonWebKeySet CreateJsonWebKeySet (string set, ClientCreateJsonWebKeySet clientCreateJsonWebKeySet)
+> Task&lt;ICreateJsonWebKeySetApiResponse&gt; CreateJsonWebKeySetAsync(string set, ClientCreateJsonWebKeySet clientCreateJsonWebKeySet, System.Threading.CancellationToken cancellationToken = default)
 
 Create JSON Web Key
 
 This endpoint is capable of generating JSON Web Key Sets for you. There are different strategies available, such as symmetric cryptographic keys (HS256, HS512) and asymmetric cryptographic keys (RS256, ECDSA). If the specified JSON Web Key Set does not exist, it will be created.  If the set already exists, the newly generated key is added to it and all existing keys are kept. This allows you to rotate keys: tokens signed with an older key in the set remain verifiable. Exception: when Ory Hydra is configured to use a Hardware Security Module (HSM), generating a key replaces the set, which then contains only the new key. To replace a set and all of its keys instead, use the `setJsonWebKeySet` operation (`PUT /admin/keys/{set}`).  A JSON Web Key (JWK) is a JavaScript Object Notation (JSON) data structure that represents a cryptographic key. A JWK Set is a JSON data structure that represents a set of JWKs. A JSON Web Key is identified by its set and key id. ORY Hydra uses this functionality to store cryptographic keys used for TLS and JSON Web Tokens (such as OpenID Connect ID tokens), and allows storing user-defined keys as well.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class CreateJsonWebKeySetExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IJwkApi>();
+            string set = default!; // The JSON Web Key Set ID
+            ClientCreateJsonWebKeySet clientCreateJsonWebKeySet = default!; // 
+            var response = await api.CreateJsonWebKeySetAsync(set, clientCreateJsonWebKeySet);
+            ClientJsonWebKeySet? model = response.Created();
+        }
+    }
+}
+```
 
 ### Parameters
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
 | **set** | **string** | The JSON Web Key Set ID |  |
-| **clientCreateJsonWebKeySet** | [**ClientCreateJsonWebKeySet**](ClientCreateJsonWebKeySet.md) |  |  |
+| **clientCreateJsonWebKeySet** | [**ClientCreateJsonWebKeySet**](../models/ClientCreateJsonWebKeySet.md) |  |  |
 
 ### Return type
 
-[**ClientJsonWebKeySet**](ClientJsonWebKeySet.md)
+[**ClientJsonWebKeySet**](../models/ClientJsonWebKeySet.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -52,12 +87,46 @@ This endpoint is capable of generating JSON Web Key Sets for you. There are diff
 
 <a id="deletejsonwebkey"></a>
 # **DeleteJsonWebKey**
-> void DeleteJsonWebKey (string set, string kid)
+> Task&lt;IDeleteJsonWebKeyApiResponse&gt; DeleteJsonWebKeyAsync(string set, string kid, System.Threading.CancellationToken cancellationToken = default)
 
 Delete JSON Web Key
 
 Use this endpoint to delete a single JSON Web Key.  A JSON Web Key (JWK) is a JavaScript Object Notation (JSON) data structure that represents a cryptographic key. A JWK Set is a JSON data structure that represents a set of JWKs. A JSON Web Key is identified by its set and key id. ORY Hydra uses this functionality to store cryptographic keys used for TLS and JSON Web Tokens (such as OpenID Connect ID tokens), and allows storing user-defined keys as well.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class DeleteJsonWebKeyExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IJwkApi>();
+            string set = default!; // The JSON Web Key Set
+            string kid = default!; // The JSON Web Key ID (kid)
+            await api.DeleteJsonWebKeyAsync(set, kid);
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -72,7 +141,7 @@ void (empty response body)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -90,12 +159,45 @@ void (empty response body)
 
 <a id="deletejsonwebkeyset"></a>
 # **DeleteJsonWebKeySet**
-> void DeleteJsonWebKeySet (string set)
+> Task&lt;IDeleteJsonWebKeySetApiResponse&gt; DeleteJsonWebKeySetAsync(string set, System.Threading.CancellationToken cancellationToken = default)
 
 Delete JSON Web Key Set
 
 Use this endpoint to delete a complete JSON Web Key Set and all the keys in that set.  A JSON Web Key (JWK) is a JavaScript Object Notation (JSON) data structure that represents a cryptographic key. A JWK Set is a JSON data structure that represents a set of JWKs. A JSON Web Key is identified by its set and key id. ORY Hydra uses this functionality to store cryptographic keys used for TLS and JSON Web Tokens (such as OpenID Connect ID tokens), and allows storing user-defined keys as well.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class DeleteJsonWebKeySetExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IJwkApi>();
+            string set = default!; // The JSON Web Key Set
+            await api.DeleteJsonWebKeySetAsync(set);
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -109,7 +211,7 @@ void (empty response body)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -127,12 +229,47 @@ void (empty response body)
 
 <a id="getjsonwebkey"></a>
 # **GetJsonWebKey**
-> ClientJsonWebKeySet GetJsonWebKey (string set, string kid)
+> Task&lt;IGetJsonWebKeyApiResponse&gt; GetJsonWebKeyAsync(string set, string kid, System.Threading.CancellationToken cancellationToken = default)
 
 Get JSON Web Key
 
 This endpoint returns a singular JSON Web Key contained in a set. It is identified by the set and the specific key ID (kid).
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class GetJsonWebKeyExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IJwkApi>();
+            string set = default!; // JSON Web Key Set ID
+            string kid = default!; // JSON Web Key ID
+            var response = await api.GetJsonWebKeyAsync(set, kid);
+            ClientJsonWebKeySet? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -143,11 +280,11 @@ This endpoint returns a singular JSON Web Key contained in a set. It is identifi
 
 ### Return type
 
-[**ClientJsonWebKeySet**](ClientJsonWebKeySet.md)
+[**ClientJsonWebKeySet**](../models/ClientJsonWebKeySet.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -165,12 +302,46 @@ This endpoint returns a singular JSON Web Key contained in a set. It is identifi
 
 <a id="getjsonwebkeyset"></a>
 # **GetJsonWebKeySet**
-> ClientJsonWebKeySet GetJsonWebKeySet (string set)
+> Task&lt;IGetJsonWebKeySetApiResponse&gt; GetJsonWebKeySetAsync(string set, System.Threading.CancellationToken cancellationToken = default)
 
 Retrieve a JSON Web Key Set
 
 This endpoint can be used to retrieve JWK Sets stored in ORY Hydra.  A JSON Web Key (JWK) is a JavaScript Object Notation (JSON) data structure that represents a cryptographic key. A JWK Set is a JSON data structure that represents a set of JWKs. A JSON Web Key is identified by its set and key id. ORY Hydra uses this functionality to store cryptographic keys used for TLS and JSON Web Tokens (such as OpenID Connect ID tokens), and allows storing user-defined keys as well.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class GetJsonWebKeySetExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IJwkApi>();
+            string set = default!; // JSON Web Key Set ID
+            var response = await api.GetJsonWebKeySetAsync(set);
+            ClientJsonWebKeySet? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -180,11 +351,11 @@ This endpoint can be used to retrieve JWK Sets stored in ORY Hydra.  A JSON Web 
 
 ### Return type
 
-[**ClientJsonWebKeySet**](ClientJsonWebKeySet.md)
+[**ClientJsonWebKeySet**](../models/ClientJsonWebKeySet.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -202,12 +373,48 @@ This endpoint can be used to retrieve JWK Sets stored in ORY Hydra.  A JSON Web 
 
 <a id="setjsonwebkey"></a>
 # **SetJsonWebKey**
-> ClientJsonWebKey SetJsonWebKey (string set, string kid, ClientJsonWebKey clientJsonWebKey = null)
+> Task&lt;ISetJsonWebKeyApiResponse&gt; SetJsonWebKeyAsync(string set, string kid, Option<ClientJsonWebKey> clientJsonWebKey = default, System.Threading.CancellationToken cancellationToken = default)
 
 Set JSON Web Key
 
 Use this method if you do not want to let Hydra generate the JWKs for you, but instead save your own.  Warning: the key is created or updated under the `kid` given in the request body. The `{kid}` path parameter exists for historical reasons only: it is ignored and not validated against the body.  A JSON Web Key (JWK) is a JavaScript Object Notation (JSON) data structure that represents a cryptographic key. A JWK Set is a JSON data structure that represents a set of JWKs. A JSON Web Key is identified by its set and key id. ORY Hydra uses this functionality to store cryptographic keys used for TLS and JSON Web Tokens (such as OpenID Connect ID tokens), and allows storing user-defined keys as well.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class SetJsonWebKeyExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IJwkApi>();
+            string set = default!; // The JSON Web Key Set ID
+            string kid = default!; // JSON Web Key ID
+            Option<ClientJsonWebKey> clientJsonWebKey = default!; //  (optional)
+            var response = await api.SetJsonWebKeyAsync(set, kid, clientJsonWebKey);
+            ClientJsonWebKey? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -215,15 +422,15 @@ Use this method if you do not want to let Hydra generate the JWKs for you, but i
 |------|------|-------------|-------|
 | **set** | **string** | The JSON Web Key Set ID |  |
 | **kid** | **string** | JSON Web Key ID |  |
-| **clientJsonWebKey** | [**ClientJsonWebKey**](ClientJsonWebKey.md) |  | [optional]  |
+| **clientJsonWebKey** | [**ClientJsonWebKey**](../models/ClientJsonWebKey.md) |  | [optional]  |
 
 ### Return type
 
-[**ClientJsonWebKey**](ClientJsonWebKey.md)
+[**ClientJsonWebKey**](../models/ClientJsonWebKey.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -241,27 +448,62 @@ Use this method if you do not want to let Hydra generate the JWKs for you, but i
 
 <a id="setjsonwebkeyset"></a>
 # **SetJsonWebKeySet**
-> ClientJsonWebKeySet SetJsonWebKeySet (string set, ClientJsonWebKeySet clientJsonWebKeySet = null)
+> Task&lt;ISetJsonWebKeySetApiResponse&gt; SetJsonWebKeySetAsync(string set, Option<ClientJsonWebKeySet> clientJsonWebKeySet = default, System.Threading.CancellationToken cancellationToken = default)
 
 Update a JSON Web Key Set
 
 Use this method if you do not want to let Hydra generate the JWKs for you, but instead save your own.  This operation replaces the entire JSON Web Key Set: keys that exist in the set but are not part of the request body are deleted. To add a newly generated key to the set while keeping the existing keys, use the `createJsonWebKeySet` operation (`POST /admin/keys/{set}`).  A JSON Web Key (JWK) is a JavaScript Object Notation (JSON) data structure that represents a cryptographic key. A JWK Set is a JSON data structure that represents a set of JWKs. A JSON Web Key is identified by its set and key id. ORY Hydra uses this functionality to store cryptographic keys used for TLS and JSON Web Tokens (such as OpenID Connect ID tokens), and allows storing user-defined keys as well.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class SetJsonWebKeySetExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IJwkApi>();
+            string set = default!; // The JSON Web Key Set ID
+            Option<ClientJsonWebKeySet> clientJsonWebKeySet = default!; //  (optional)
+            var response = await api.SetJsonWebKeySetAsync(set, clientJsonWebKeySet);
+            ClientJsonWebKeySet? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
 | **set** | **string** | The JSON Web Key Set ID |  |
-| **clientJsonWebKeySet** | [**ClientJsonWebKeySet**](ClientJsonWebKeySet.md) |  | [optional]  |
+| **clientJsonWebKeySet** | [**ClientJsonWebKeySet**](../models/ClientJsonWebKeySet.md) |  | [optional]  |
 
 ### Return type
 
-[**ClientJsonWebKeySet**](ClientJsonWebKeySet.md)
+[**ClientJsonWebKeySet**](../models/ClientJsonWebKeySet.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 

--- a/clients/client/dotnet/docs/apis/MetadataApi.md
+++ b/clients/client/dotnet/docs/apis/MetadataApi.md
@@ -8,22 +8,55 @@ All URIs are relative to *https://playground.projects.oryapis.com*
 
 <a id="getversion"></a>
 # **GetVersion**
-> ClientGetVersion200Response GetVersion ()
+> Task&lt;IGetVersionApiResponse&gt; GetVersionAsync(System.Threading.CancellationToken cancellationToken = default)
 
 Return Running Software Version.
 
 This endpoint returns the version of Ory Kratos.  If the service supports TLS Edge Termination, this endpoint does not require the `X-Forwarded-Proto` header to be set.  Be aware that if you are running multiple nodes of this service, the version will never refer to the cluster state, only to a single instance.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class GetVersionExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IMetadataApi>();
+            var response = await api.GetVersionAsync();
+            ClientGetVersion200Response? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 This endpoint does not need any parameter.
 ### Return type
 
-[**ClientGetVersion200Response**](ClientGetVersion200Response.md)
+[**ClientGetVersion200Response**](../models/ClientGetVersion200Response.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 

--- a/clients/client/dotnet/docs/apis/OAuth2Api.md
+++ b/clients/client/dotnet/docs/apis/OAuth2Api.md
@@ -40,27 +40,62 @@ All URIs are relative to *https://playground.projects.oryapis.com*
 
 <a id="acceptoauth2consentrequest"></a>
 # **AcceptOAuth2ConsentRequest**
-> ClientOAuth2RedirectTo AcceptOAuth2ConsentRequest (string consentChallenge, ClientAcceptOAuth2ConsentRequest clientAcceptOAuth2ConsentRequest = null)
+> Task&lt;IAcceptOAuth2ConsentRequestApiResponse&gt; AcceptOAuth2ConsentRequestAsync(string consentChallenge, Option<ClientAcceptOAuth2ConsentRequest> clientAcceptOAuth2ConsentRequest = default, System.Threading.CancellationToken cancellationToken = default)
 
 Accept OAuth 2.0 Consent Request
 
 When an authorization code, hybrid, or implicit OAuth 2.0 Flow is initiated, Ory asks the login provider to authenticate the subject and then tell Ory now about it. If the subject authenticated, he/she must now be asked if the OAuth 2.0 Client which initiated the flow should be allowed to access the resources on the subject's behalf.  The consent challenge is appended to the consent provider's URL to which the subject's user-agent (browser) is redirected to. The consent provider uses that challenge to fetch information on the OAuth2 request and then tells Ory if the subject accepted or rejected the request.  This endpoint tells Ory that the subject has authorized the OAuth 2.0 client to access resources on his/her behalf. The consent provider includes additional information, such as session data for access and ID tokens, and if the consent request should be used as basis for future requests.  The response contains a redirect URL which the consent provider should redirect the user-agent to.  The default consent provider is available via the Ory Managed Account Experience. To customize the consent provider, please head over to the OAuth 2.0 documentation.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class AcceptOAuth2ConsentRequestExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IOAuth2Api>();
+            string consentChallenge = default!; // OAuth 2.0 Consent Request Challenge
+            Option<ClientAcceptOAuth2ConsentRequest> clientAcceptOAuth2ConsentRequest = default!; //  (optional)
+            var response = await api.AcceptOAuth2ConsentRequestAsync(consentChallenge, clientAcceptOAuth2ConsentRequest);
+            ClientOAuth2RedirectTo? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
 | **consentChallenge** | **string** | OAuth 2.0 Consent Request Challenge |  |
-| **clientAcceptOAuth2ConsentRequest** | [**ClientAcceptOAuth2ConsentRequest**](ClientAcceptOAuth2ConsentRequest.md) |  | [optional]  |
+| **clientAcceptOAuth2ConsentRequest** | [**ClientAcceptOAuth2ConsentRequest**](../models/ClientAcceptOAuth2ConsentRequest.md) |  | [optional]  |
 
 ### Return type
 
-[**ClientOAuth2RedirectTo**](ClientOAuth2RedirectTo.md)
+[**ClientOAuth2RedirectTo**](../models/ClientOAuth2RedirectTo.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -78,27 +113,62 @@ When an authorization code, hybrid, or implicit OAuth 2.0 Flow is initiated, Ory
 
 <a id="acceptoauth2loginrequest"></a>
 # **AcceptOAuth2LoginRequest**
-> ClientOAuth2RedirectTo AcceptOAuth2LoginRequest (string loginChallenge, ClientAcceptOAuth2LoginRequest clientAcceptOAuth2LoginRequest = null)
+> Task&lt;IAcceptOAuth2LoginRequestApiResponse&gt; AcceptOAuth2LoginRequestAsync(string loginChallenge, Option<ClientAcceptOAuth2LoginRequest> clientAcceptOAuth2LoginRequest = default, System.Threading.CancellationToken cancellationToken = default)
 
 Accept OAuth 2.0 Login Request
 
 When an authorization code, hybrid, or implicit OAuth 2.0 Flow is initiated, Ory asks the login provider to authenticate the subject and then tell the Ory OAuth2 Service about it.  The authentication challenge is appended to the login provider URL to which the subject's user-agent (browser) is redirected to. The login provider uses that challenge to fetch information on the OAuth2 request and then accept or reject the requested authentication process.  This endpoint tells Ory that the subject has successfully authenticated and includes additional information such as the subject's ID and if Ory should remember the subject's subject agent for future authentication attempts by setting a cookie.  The response contains a redirect URL which the login provider should redirect the user-agent to.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class AcceptOAuth2LoginRequestExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IOAuth2Api>();
+            string loginChallenge = default!; // OAuth 2.0 Login Request Challenge
+            Option<ClientAcceptOAuth2LoginRequest> clientAcceptOAuth2LoginRequest = default!; //  (optional)
+            var response = await api.AcceptOAuth2LoginRequestAsync(loginChallenge, clientAcceptOAuth2LoginRequest);
+            ClientOAuth2RedirectTo? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
 | **loginChallenge** | **string** | OAuth 2.0 Login Request Challenge |  |
-| **clientAcceptOAuth2LoginRequest** | [**ClientAcceptOAuth2LoginRequest**](ClientAcceptOAuth2LoginRequest.md) |  | [optional]  |
+| **clientAcceptOAuth2LoginRequest** | [**ClientAcceptOAuth2LoginRequest**](../models/ClientAcceptOAuth2LoginRequest.md) |  | [optional]  |
 
 ### Return type
 
-[**ClientOAuth2RedirectTo**](ClientOAuth2RedirectTo.md)
+[**ClientOAuth2RedirectTo**](../models/ClientOAuth2RedirectTo.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -116,12 +186,46 @@ When an authorization code, hybrid, or implicit OAuth 2.0 Flow is initiated, Ory
 
 <a id="acceptoauth2logoutrequest"></a>
 # **AcceptOAuth2LogoutRequest**
-> ClientOAuth2RedirectTo AcceptOAuth2LogoutRequest (string logoutChallenge)
+> Task&lt;IAcceptOAuth2LogoutRequestApiResponse&gt; AcceptOAuth2LogoutRequestAsync(string logoutChallenge, System.Threading.CancellationToken cancellationToken = default)
 
 Accept OAuth 2.0 Session Logout Request
 
 When a user or an application requests Ory OAuth 2.0 to remove the session state of a subject, this endpoint is used to confirm that logout request.  The response contains a redirect URL which the consent provider should redirect the user-agent to.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class AcceptOAuth2LogoutRequestExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IOAuth2Api>();
+            string logoutChallenge = default!; // OAuth 2.0 Logout Request Challenge
+            var response = await api.AcceptOAuth2LogoutRequestAsync(logoutChallenge);
+            ClientOAuth2RedirectTo? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -131,11 +235,11 @@ When a user or an application requests Ory OAuth 2.0 to remove the session state
 
 ### Return type
 
-[**ClientOAuth2RedirectTo**](ClientOAuth2RedirectTo.md)
+[**ClientOAuth2RedirectTo**](../models/ClientOAuth2RedirectTo.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -153,27 +257,62 @@ When a user or an application requests Ory OAuth 2.0 to remove the session state
 
 <a id="acceptusercoderequest"></a>
 # **AcceptUserCodeRequest**
-> ClientOAuth2RedirectTo AcceptUserCodeRequest (string deviceChallenge, ClientAcceptDeviceUserCodeRequest clientAcceptDeviceUserCodeRequest = null)
+> Task&lt;IAcceptUserCodeRequestApiResponse&gt; AcceptUserCodeRequestAsync(string deviceChallenge, Option<ClientAcceptDeviceUserCodeRequest> clientAcceptDeviceUserCodeRequest = default, System.Threading.CancellationToken cancellationToken = default)
 
 Accepts a device grant user_code request
 
 Accepts a device grant user_code request
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class AcceptUserCodeRequestExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IOAuth2Api>();
+            string deviceChallenge = default!; // 
+            Option<ClientAcceptDeviceUserCodeRequest> clientAcceptDeviceUserCodeRequest = default!; //  (optional)
+            var response = await api.AcceptUserCodeRequestAsync(deviceChallenge, clientAcceptDeviceUserCodeRequest);
+            ClientOAuth2RedirectTo? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
 | **deviceChallenge** | **string** |  |  |
-| **clientAcceptDeviceUserCodeRequest** | [**ClientAcceptDeviceUserCodeRequest**](ClientAcceptDeviceUserCodeRequest.md) |  | [optional]  |
+| **clientAcceptDeviceUserCodeRequest** | [**ClientAcceptDeviceUserCodeRequest**](../models/ClientAcceptDeviceUserCodeRequest.md) |  | [optional]  |
 
 ### Return type
 
-[**ClientOAuth2RedirectTo**](ClientOAuth2RedirectTo.md)
+[**ClientOAuth2RedirectTo**](../models/ClientOAuth2RedirectTo.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -191,26 +330,60 @@ Accepts a device grant user_code request
 
 <a id="createoauth2client"></a>
 # **CreateOAuth2Client**
-> ClientOAuth2Client CreateOAuth2Client (ClientOAuth2Client clientOAuth2Client)
+> Task&lt;ICreateOAuth2ClientApiResponse&gt; CreateOAuth2ClientAsync(ClientOAuth2Client clientOAuth2Client, System.Threading.CancellationToken cancellationToken = default)
 
 Create OAuth 2.0 Client
 
 Create a new OAuth 2.0 client. If you pass `client_secret` the secret is used, otherwise a random secret is generated. The secret is echoed in the response. It is not possible to retrieve it later on.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class CreateOAuth2ClientExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IOAuth2Api>();
+            ClientOAuth2Client clientOAuth2Client = default!; // OAuth 2.0 Client Request Body
+            var response = await api.CreateOAuth2ClientAsync(clientOAuth2Client);
+            ClientOAuth2Client? model = response.Created();
+        }
+    }
+}
+```
 
 ### Parameters
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **clientOAuth2Client** | [**ClientOAuth2Client**](ClientOAuth2Client.md) | OAuth 2.0 Client Request Body |  |
+| **clientOAuth2Client** | [**ClientOAuth2Client**](../models/ClientOAuth2Client.md) | OAuth 2.0 Client Request Body |  |
 
 ### Return type
 
-[**ClientOAuth2Client**](ClientOAuth2Client.md)
+[**ClientOAuth2Client**](../models/ClientOAuth2Client.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -229,12 +402,45 @@ Create a new OAuth 2.0 client. If you pass `client_secret` the secret is used, o
 
 <a id="deleteoauth2client"></a>
 # **DeleteOAuth2Client**
-> void DeleteOAuth2Client (string id)
+> Task&lt;IDeleteOAuth2ClientApiResponse&gt; DeleteOAuth2ClientAsync(string id, System.Threading.CancellationToken cancellationToken = default)
 
 Delete OAuth 2.0 Client
 
 Delete an existing OAuth 2.0 Client by its ID.  OAuth 2.0 clients are used to perform OAuth 2.0 and OpenID Connect flows. Usually, OAuth 2.0 clients are generated for applications which want to consume your OAuth 2.0 or OpenID Connect capabilities.  Make sure that this endpoint is well protected and only callable by first-party components.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class DeleteOAuth2ClientExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IOAuth2Api>();
+            string id = default!; // The id of the OAuth 2.0 Client.
+            await api.DeleteOAuth2ClientAsync(id);
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -248,7 +454,7 @@ void (empty response body)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -266,12 +472,45 @@ void (empty response body)
 
 <a id="deleteoauth2token"></a>
 # **DeleteOAuth2Token**
-> void DeleteOAuth2Token (string clientId)
+> Task&lt;IDeleteOAuth2TokenApiResponse&gt; DeleteOAuth2TokenAsync(string clientId, System.Threading.CancellationToken cancellationToken = default)
 
 Delete OAuth 2.0 Access Tokens from specific OAuth 2.0 Client
 
 This endpoint deletes OAuth2 access tokens issued to an OAuth 2.0 Client from the database.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class DeleteOAuth2TokenExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IOAuth2Api>();
+            string clientId = default!; // OAuth 2.0 Client ID
+            await api.DeleteOAuth2TokenAsync(clientId);
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -285,7 +524,7 @@ void (empty response body)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -303,12 +542,46 @@ void (empty response body)
 
 <a id="deleterotatedoauth2clientsecrets"></a>
 # **DeleteRotatedOAuth2ClientSecrets**
-> ClientOAuth2Client DeleteRotatedOAuth2ClientSecrets (string id)
+> Task&lt;IDeleteRotatedOAuth2ClientSecretsApiResponse&gt; DeleteRotatedOAuth2ClientSecretsAsync(string id, System.Threading.CancellationToken cancellationToken = default)
 
 Delete Rotated OAuth 2.0 Client Secrets
 
 Removes all rotated secrets from an OAuth 2.0 client. This should be called after all services have been updated to use the new secret and the old secrets are no longer needed.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class DeleteRotatedOAuth2ClientSecretsExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IOAuth2Api>();
+            string id = default!; // OAuth 2.0 Client ID
+            var response = await api.DeleteRotatedOAuth2ClientSecretsAsync(id);
+            ClientOAuth2Client? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -318,11 +591,11 @@ Removes all rotated secrets from an OAuth 2.0 client. This should be called afte
 
 ### Return type
 
-[**ClientOAuth2Client**](ClientOAuth2Client.md)
+[**ClientOAuth2Client**](../models/ClientOAuth2Client.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -341,12 +614,45 @@ Removes all rotated secrets from an OAuth 2.0 client. This should be called afte
 
 <a id="deletetrustedoauth2jwtgrantissuer"></a>
 # **DeleteTrustedOAuth2JwtGrantIssuer**
-> void DeleteTrustedOAuth2JwtGrantIssuer (string id)
+> Task&lt;IDeleteTrustedOAuth2JwtGrantIssuerApiResponse&gt; DeleteTrustedOAuth2JwtGrantIssuerAsync(string id, System.Threading.CancellationToken cancellationToken = default)
 
 Delete Trusted OAuth2 JWT Bearer Grant Type Issuer
 
 Use this endpoint to delete trusted JWT Bearer Grant Type Issuer. The ID is the one returned when you created the trust relationship.  Once deleted, the associated issuer will no longer be able to perform the JSON Web Token (JWT) Profile for OAuth 2.0 Client Authentication and Authorization Grant.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class DeleteTrustedOAuth2JwtGrantIssuerExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IOAuth2Api>();
+            string id = default!; // The id of the desired grant
+            await api.DeleteTrustedOAuth2JwtGrantIssuerAsync(id);
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -360,7 +666,7 @@ void (empty response body)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -378,12 +684,46 @@ void (empty response body)
 
 <a id="getoauth2client"></a>
 # **GetOAuth2Client**
-> ClientOAuth2Client GetOAuth2Client (string id)
+> Task&lt;IGetOAuth2ClientApiResponse&gt; GetOAuth2ClientAsync(string id, System.Threading.CancellationToken cancellationToken = default)
 
 Get an OAuth 2.0 Client
 
 Get an OAuth 2.0 client by its ID. This endpoint never returns the client secret.  OAuth 2.0 clients are used to perform OAuth 2.0 and OpenID Connect flows. Usually, OAuth 2.0 clients are generated for applications which want to consume your OAuth 2.0 or OpenID Connect capabilities.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class GetOAuth2ClientExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IOAuth2Api>();
+            string id = default!; // The id of the OAuth 2.0 Client.
+            var response = await api.GetOAuth2ClientAsync(id);
+            ClientOAuth2Client? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -393,11 +733,11 @@ Get an OAuth 2.0 client by its ID. This endpoint never returns the client secret
 
 ### Return type
 
-[**ClientOAuth2Client**](ClientOAuth2Client.md)
+[**ClientOAuth2Client**](../models/ClientOAuth2Client.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -415,12 +755,46 @@ Get an OAuth 2.0 client by its ID. This endpoint never returns the client secret
 
 <a id="getoauth2consentrequest"></a>
 # **GetOAuth2ConsentRequest**
-> ClientOAuth2ConsentRequest GetOAuth2ConsentRequest (string consentChallenge)
+> Task&lt;IGetOAuth2ConsentRequestApiResponse&gt; GetOAuth2ConsentRequestAsync(string consentChallenge, System.Threading.CancellationToken cancellationToken = default)
 
 Get OAuth 2.0 Consent Request
 
 When an authorization code, hybrid, or implicit OAuth 2.0 Flow is initiated, Ory asks the login provider to authenticate the subject and then tell Ory now about it. If the subject authenticated, he/she must now be asked if the OAuth 2.0 Client which initiated the flow should be allowed to access the resources on the subject's behalf.  The consent challenge is appended to the consent provider's URL to which the subject's user-agent (browser) is redirected to. The consent provider uses that challenge to fetch information on the OAuth2 request and then tells Ory if the subject accepted or rejected the request.  The default consent provider is available via the Ory Managed Account Experience. To customize the consent provider, please head over to the OAuth 2.0 documentation.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class GetOAuth2ConsentRequestExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IOAuth2Api>();
+            string consentChallenge = default!; // OAuth 2.0 Consent Request Challenge
+            var response = await api.GetOAuth2ConsentRequestAsync(consentChallenge);
+            ClientOAuth2ConsentRequest? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -430,11 +804,11 @@ When an authorization code, hybrid, or implicit OAuth 2.0 Flow is initiated, Ory
 
 ### Return type
 
-[**ClientOAuth2ConsentRequest**](ClientOAuth2ConsentRequest.md)
+[**ClientOAuth2ConsentRequest**](../models/ClientOAuth2ConsentRequest.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -453,12 +827,46 @@ When an authorization code, hybrid, or implicit OAuth 2.0 Flow is initiated, Ory
 
 <a id="getoauth2loginrequest"></a>
 # **GetOAuth2LoginRequest**
-> ClientOAuth2LoginRequest GetOAuth2LoginRequest (string loginChallenge)
+> Task&lt;IGetOAuth2LoginRequestApiResponse&gt; GetOAuth2LoginRequestAsync(string loginChallenge, System.Threading.CancellationToken cancellationToken = default)
 
 Get OAuth 2.0 Login Request
 
 When an authorization code, hybrid, or implicit OAuth 2.0 Flow is initiated, Ory asks the login provider to authenticate the subject and then tell the Ory OAuth2 Service about it.  Per default, the login provider is Ory itself. You may use a different login provider which needs to be a web-app you write and host, and it must be able to authenticate (\"show the subject a login screen\") a subject (in OAuth2 the proper name for subject is \"resource owner\").  The authentication challenge is appended to the login provider URL to which the subject's user-agent (browser) is redirected to. The login provider uses that challenge to fetch information on the OAuth2 request and then accept or reject the requested authentication process.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class GetOAuth2LoginRequestExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IOAuth2Api>();
+            string loginChallenge = default!; // OAuth 2.0 Login Request Challenge
+            var response = await api.GetOAuth2LoginRequestAsync(loginChallenge);
+            ClientOAuth2LoginRequest? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -468,11 +876,11 @@ When an authorization code, hybrid, or implicit OAuth 2.0 Flow is initiated, Ory
 
 ### Return type
 
-[**ClientOAuth2LoginRequest**](ClientOAuth2LoginRequest.md)
+[**ClientOAuth2LoginRequest**](../models/ClientOAuth2LoginRequest.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -491,12 +899,46 @@ When an authorization code, hybrid, or implicit OAuth 2.0 Flow is initiated, Ory
 
 <a id="getoauth2logoutrequest"></a>
 # **GetOAuth2LogoutRequest**
-> ClientOAuth2LogoutRequest GetOAuth2LogoutRequest (string logoutChallenge)
+> Task&lt;IGetOAuth2LogoutRequestApiResponse&gt; GetOAuth2LogoutRequestAsync(string logoutChallenge, System.Threading.CancellationToken cancellationToken = default)
 
 Get OAuth 2.0 Session Logout Request
 
 Use this endpoint to fetch an Ory OAuth 2.0 logout request.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class GetOAuth2LogoutRequestExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IOAuth2Api>();
+            string logoutChallenge = default!; // 
+            var response = await api.GetOAuth2LogoutRequestAsync(logoutChallenge);
+            ClientOAuth2LogoutRequest? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -506,11 +948,11 @@ Use this endpoint to fetch an Ory OAuth 2.0 logout request.
 
 ### Return type
 
-[**ClientOAuth2LogoutRequest**](ClientOAuth2LogoutRequest.md)
+[**ClientOAuth2LogoutRequest**](../models/ClientOAuth2LogoutRequest.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -528,12 +970,46 @@ Use this endpoint to fetch an Ory OAuth 2.0 logout request.
 
 <a id="gettrustedoauth2jwtgrantissuer"></a>
 # **GetTrustedOAuth2JwtGrantIssuer**
-> ClientTrustedOAuth2JwtGrantIssuer GetTrustedOAuth2JwtGrantIssuer (string id)
+> Task&lt;IGetTrustedOAuth2JwtGrantIssuerApiResponse&gt; GetTrustedOAuth2JwtGrantIssuerAsync(string id, System.Threading.CancellationToken cancellationToken = default)
 
 Get Trusted OAuth2 JWT Bearer Grant Type Issuer
 
 Use this endpoint to get a trusted JWT Bearer Grant Type Issuer. The ID is the one returned when you created the trust relationship.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class GetTrustedOAuth2JwtGrantIssuerExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IOAuth2Api>();
+            string id = default!; // The id of the desired grant
+            var response = await api.GetTrustedOAuth2JwtGrantIssuerAsync(id);
+            ClientTrustedOAuth2JwtGrantIssuer? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -543,11 +1019,11 @@ Use this endpoint to get a trusted JWT Bearer Grant Type Issuer. The ID is the o
 
 ### Return type
 
-[**ClientTrustedOAuth2JwtGrantIssuer**](ClientTrustedOAuth2JwtGrantIssuer.md)
+[**ClientTrustedOAuth2JwtGrantIssuer**](../models/ClientTrustedOAuth2JwtGrantIssuer.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -565,12 +1041,47 @@ Use this endpoint to get a trusted JWT Bearer Grant Type Issuer. The ID is the o
 
 <a id="introspectoauth2token"></a>
 # **IntrospectOAuth2Token**
-> ClientIntrospectedOAuth2Token IntrospectOAuth2Token (string token, string scope = null)
+> Task&lt;IIntrospectOAuth2TokenApiResponse&gt; IntrospectOAuth2TokenAsync(string token, Option<string> scope = default, System.Threading.CancellationToken cancellationToken = default)
 
 Introspect OAuth2 Access and Refresh Tokens
 
 The introspection endpoint allows to check if a token (both refresh and access) is active or not. An active token is neither expired nor revoked. If a token is active, additional information on the token will be included. You can set additional data for a token by setting `session.access_token` during the consent flow.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class IntrospectOAuth2TokenExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IOAuth2Api>();
+            string token = default!; // The string value of the token. For access tokens, this is the \\\"access_token\\\" value returned from the token endpoint defined in OAuth 2.0. For refresh tokens, this is the \\\"refresh_token\\\" value returned.
+            Option<string> scope = default!; // An optional, space separated list of required scopes. If the access token was not granted one of the scopes, the result of active will be false. (optional)
+            var response = await api.IntrospectOAuth2TokenAsync(token, scope);
+            ClientIntrospectedOAuth2Token? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -581,11 +1092,11 @@ The introspection endpoint allows to check if a token (both refresh and access) 
 
 ### Return type
 
-[**ClientIntrospectedOAuth2Token**](ClientIntrospectedOAuth2Token.md)
+[**ClientIntrospectedOAuth2Token**](../models/ClientIntrospectedOAuth2Token.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -603,12 +1114,49 @@ The introspection endpoint allows to check if a token (both refresh and access) 
 
 <a id="listoauth2clients"></a>
 # **ListOAuth2Clients**
-> List&lt;ClientOAuth2Client&gt; ListOAuth2Clients (long pageSize = null, string pageToken = null, string clientName = null, string owner = null)
+> Task&lt;IListOAuth2ClientsApiResponse&gt; ListOAuth2ClientsAsync(Option<long> pageSize = default, Option<string> pageToken = default, Option<string> clientName = default, Option<string> owner = default, System.Threading.CancellationToken cancellationToken = default)
 
 List OAuth 2.0 Clients
 
 This endpoint lists all clients in the database, and never returns client secrets. As a default it lists the first 100 clients.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class ListOAuth2ClientsExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IOAuth2Api>();
+            Option<long> pageSize = default!; // Items per Page  This is the number of items per page to return. For details on pagination please head over to the [pagination documentation](https://www.ory.com/docs/ecosystem/api-design#pagination). (optional)
+            Option<string> pageToken = default!; // Next Page Token  The next page token. For details on pagination please head over to the [pagination documentation](https://www.ory.com/docs/ecosystem/api-design#pagination). (optional)
+            Option<string> clientName = default!; // The name of the clients to filter by. (optional)
+            Option<string> owner = default!; // The owner of the clients to filter by. (optional)
+            var response = await api.ListOAuth2ClientsAsync(pageSize, pageToken, clientName, owner);
+            List<ClientOAuth2Client>? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -621,11 +1169,11 @@ This endpoint lists all clients in the database, and never returns client secret
 
 ### Return type
 
-[**List&lt;ClientOAuth2Client&gt;**](ClientOAuth2Client.md)
+[**List&lt;ClientOAuth2Client&gt;**](../models/ClientOAuth2Client.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -643,12 +1191,49 @@ This endpoint lists all clients in the database, and never returns client secret
 
 <a id="listoauth2consentsessions"></a>
 # **ListOAuth2ConsentSessions**
-> List&lt;ClientOAuth2ConsentSession&gt; ListOAuth2ConsentSessions (string subject, long pageSize = null, string pageToken = null, string loginSessionId = null)
+> Task&lt;IListOAuth2ConsentSessionsApiResponse&gt; ListOAuth2ConsentSessionsAsync(string subject, Option<long> pageSize = default, Option<string> pageToken = default, Option<string> loginSessionId = default, System.Threading.CancellationToken cancellationToken = default)
 
 List OAuth 2.0 Consent Sessions of a Subject
 
 This endpoint lists all subject's granted consent sessions, including client and granted scope. If the subject is unknown or has not granted any consent sessions yet, the endpoint returns an empty JSON array with status code 200 OK.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class ListOAuth2ConsentSessionsExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IOAuth2Api>();
+            string subject = default!; // The subject to list the consent sessions for.
+            Option<long> pageSize = default!; // Items per Page  This is the number of items per page to return. For details on pagination please head over to the [pagination documentation](https://www.ory.com/docs/ecosystem/api-design#pagination). (optional)
+            Option<string> pageToken = default!; // Next Page Token  The next page token. For details on pagination please head over to the [pagination documentation](https://www.ory.com/docs/ecosystem/api-design#pagination). (optional)
+            Option<string> loginSessionId = default!; // The login session id to list the consent sessions for. (optional)
+            var response = await api.ListOAuth2ConsentSessionsAsync(subject, pageSize, pageToken, loginSessionId);
+            List<ClientOAuth2ConsentSession>? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -661,11 +1246,11 @@ This endpoint lists all subject's granted consent sessions, including client and
 
 ### Return type
 
-[**List&lt;ClientOAuth2ConsentSession&gt;**](ClientOAuth2ConsentSession.md)
+[**List&lt;ClientOAuth2ConsentSession&gt;**](../models/ClientOAuth2ConsentSession.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -683,12 +1268,48 @@ This endpoint lists all subject's granted consent sessions, including client and
 
 <a id="listtrustedoauth2jwtgrantissuers"></a>
 # **ListTrustedOAuth2JwtGrantIssuers**
-> List&lt;ClientTrustedOAuth2JwtGrantIssuer&gt; ListTrustedOAuth2JwtGrantIssuers (long pageSize = null, string pageToken = null, string issuer = null)
+> Task&lt;IListTrustedOAuth2JwtGrantIssuersApiResponse&gt; ListTrustedOAuth2JwtGrantIssuersAsync(Option<long> pageSize = default, Option<string> pageToken = default, Option<string> issuer = default, System.Threading.CancellationToken cancellationToken = default)
 
 List Trusted OAuth2 JWT Bearer Grant Type Issuers
 
 Use this endpoint to list all trusted JWT Bearer Grant Type Issuers.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class ListTrustedOAuth2JwtGrantIssuersExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IOAuth2Api>();
+            Option<long> pageSize = default!; // Items per Page  This is the number of items per page to return. For details on pagination please head over to the [pagination documentation](https://www.ory.com/docs/ecosystem/api-design#pagination). (optional)
+            Option<string> pageToken = default!; // Next Page Token  The next page token. For details on pagination please head over to the [pagination documentation](https://www.ory.com/docs/ecosystem/api-design#pagination). (optional)
+            Option<string> issuer = default!; // If optional \"issuer\" is supplied, only jwt-bearer grants with this issuer will be returned. (optional)
+            var response = await api.ListTrustedOAuth2JwtGrantIssuersAsync(pageSize, pageToken, issuer);
+            List<ClientTrustedOAuth2JwtGrantIssuer>? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -700,11 +1321,11 @@ Use this endpoint to list all trusted JWT Bearer Grant Type Issuers.
 
 ### Return type
 
-[**List&lt;ClientTrustedOAuth2JwtGrantIssuer&gt;**](ClientTrustedOAuth2JwtGrantIssuer.md)
+[**List&lt;ClientTrustedOAuth2JwtGrantIssuer&gt;**](../models/ClientTrustedOAuth2JwtGrantIssuer.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -722,18 +1343,48 @@ Use this endpoint to list all trusted JWT Bearer Grant Type Issuers.
 
 <a id="oauth2authorize"></a>
 # **OAuth2Authorize**
-> ClientErrorOAuth2 OAuth2Authorize ()
+> Task&lt;IOAuth2AuthorizeApiResponse&gt; OAuth2AuthorizeAsync(System.Threading.CancellationToken cancellationToken = default)
 
 OAuth 2.0 Authorize Endpoint
 
 Use open source libraries to perform OAuth 2.0 and OpenID Connect available for any programming language. You can find a list of libraries at https://oauth.net/code/  This endpoint should not be used via the Ory SDK and is only included for technical reasons. Instead, use one of the libraries linked above.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class OAuth2AuthorizeExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IOAuth2Api>();
+            await api.OAuth2AuthorizeAsync();
+        }
+    }
+}
+```
 
 ### Parameters
 This endpoint does not need any parameter.
 ### Return type
 
-[**ClientErrorOAuth2**](ClientErrorOAuth2.md)
+[**ClientErrorOAuth2**](../models/ClientErrorOAuth2.md)
 
 ### Authorization
 
@@ -755,18 +1406,49 @@ No authorization required
 
 <a id="oauth2deviceflow"></a>
 # **OAuth2DeviceFlow**
-> ClientDeviceAuthorization OAuth2DeviceFlow ()
+> Task&lt;IOAuth2DeviceFlowApiResponse&gt; OAuth2DeviceFlowAsync(System.Threading.CancellationToken cancellationToken = default)
 
 The OAuth 2.0 Device Authorize Endpoint
 
 This endpoint is not documented here because you should never use your own implementation to perform OAuth2 flows. OAuth2 is a very popular protocol and a library for your programming language will exist.  To learn more about this flow please refer to the specification: https://tools.ietf.org/html/rfc8628
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class OAuth2DeviceFlowExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IOAuth2Api>();
+            var response = await api.OAuth2DeviceFlowAsync();
+            ClientDeviceAuthorization? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 This endpoint does not need any parameter.
 ### Return type
 
-[**ClientDeviceAuthorization**](ClientDeviceAuthorization.md)
+[**ClientDeviceAuthorization**](../models/ClientDeviceAuthorization.md)
 
 ### Authorization
 
@@ -788,12 +1470,50 @@ No authorization required
 
 <a id="oauth2tokenexchange"></a>
 # **Oauth2TokenExchange**
-> ClientOAuth2TokenExchange Oauth2TokenExchange (string grantType, string clientId = null, string code = null, string redirectUri = null, string refreshToken = null)
+> Task&lt;IOauth2TokenExchangeApiResponse&gt; Oauth2TokenExchangeAsync(string grantType, Option<string> clientId = default, Option<string> code = default, Option<string> redirectUri = default, Option<string> refreshToken = default, System.Threading.CancellationToken cancellationToken = default)
 
 The OAuth 2.0 Token Endpoint
 
 Use open source libraries to perform OAuth 2.0 and OpenID Connect available for any programming language. You can find a list of libraries here https://oauth.net/code/  This endpoint should not be used via the Ory SDK and is only included for technical reasons. Instead, use one of the libraries linked above.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class Oauth2TokenExchangeExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IOAuth2Api>();
+            string grantType = default!; // 
+            Option<string> clientId = default!; //  (optional)
+            Option<string> code = default!; //  (optional)
+            Option<string> redirectUri = default!; //  (optional)
+            Option<string> refreshToken = default!; //  (optional)
+            var response = await api.Oauth2TokenExchangeAsync(grantType, clientId, code, redirectUri, refreshToken);
+            ClientOAuth2TokenExchange? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -807,11 +1527,11 @@ Use open source libraries to perform OAuth 2.0 and OpenID Connect available for 
 
 ### Return type
 
-[**ClientOAuth2TokenExchange**](ClientOAuth2TokenExchange.md)
+[**ClientOAuth2TokenExchange**](../models/ClientOAuth2TokenExchange.md)
 
 ### Authorization
 
-[basic](../README.md#basic), [oauth2](../README.md#oauth2)
+[basic](../../README.md#basic), [oauth2](../../README.md#oauth2)
 
 ### HTTP request headers
 
@@ -829,27 +1549,62 @@ Use open source libraries to perform OAuth 2.0 and OpenID Connect available for 
 
 <a id="patchoauth2client"></a>
 # **PatchOAuth2Client**
-> ClientOAuth2Client PatchOAuth2Client (string id, List<ClientJsonPatch> clientJsonPatch)
+> Task&lt;IPatchOAuth2ClientApiResponse&gt; PatchOAuth2ClientAsync(string id, List<ClientJsonPatch> clientJsonPatch, System.Threading.CancellationToken cancellationToken = default)
 
 Patch OAuth 2.0 Client
 
 Patch an existing OAuth 2.0 Client using JSON Patch. If you update `client_secret`, the secret will be updated and returned via the API. This is the only time you will be able to retrieve the client secret. Passing a new `client_secret` will clear all rotated secrets.  To perform a seamless client secret rotation, use the `rotateOAuth2ClientSecret` endpoint instead.  OAuth 2.0 clients are used to perform OAuth 2.0 and OpenID Connect flows. Usually, OAuth 2.0 clients are generated for applications which want to consume your OAuth 2.0 or OpenID Connect capabilities.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class PatchOAuth2ClientExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IOAuth2Api>();
+            string id = default!; // The id of the OAuth 2.0 Client.
+            List<ClientJsonPatch> clientJsonPatch = default!; // OAuth 2.0 Client JSON Patch Body
+            var response = await api.PatchOAuth2ClientAsync(id, clientJsonPatch);
+            ClientOAuth2Client? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
 | **id** | **string** | The id of the OAuth 2.0 Client. |  |
-| **clientJsonPatch** | [**List&lt;ClientJsonPatch&gt;**](ClientJsonPatch.md) | OAuth 2.0 Client JSON Patch Body |  |
+| **clientJsonPatch** | [**List&lt;ClientJsonPatch&gt;**](../models/ClientJsonPatch.md) | OAuth 2.0 Client JSON Patch Body |  |
 
 ### Return type
 
-[**ClientOAuth2Client**](ClientOAuth2Client.md)
+[**ClientOAuth2Client**](../models/ClientOAuth2Client.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -868,18 +1623,48 @@ Patch an existing OAuth 2.0 Client using JSON Patch. If you update `client_secre
 
 <a id="performoauth2deviceverificationflow"></a>
 # **PerformOAuth2DeviceVerificationFlow**
-> ClientErrorOAuth2 PerformOAuth2DeviceVerificationFlow ()
+> Task&lt;IPerformOAuth2DeviceVerificationFlowApiResponse&gt; PerformOAuth2DeviceVerificationFlowAsync(System.Threading.CancellationToken cancellationToken = default)
 
 OAuth 2.0 Device Verification Endpoint
 
 This is the device user verification endpoint. The user is redirected here when trying to log in using the device flow.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class PerformOAuth2DeviceVerificationFlowExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IOAuth2Api>();
+            await api.PerformOAuth2DeviceVerificationFlowAsync();
+        }
+    }
+}
+```
 
 ### Parameters
 This endpoint does not need any parameter.
 ### Return type
 
-[**ClientErrorOAuth2**](ClientErrorOAuth2.md)
+[**ClientErrorOAuth2**](../models/ClientErrorOAuth2.md)
 
 ### Authorization
 
@@ -901,27 +1686,62 @@ No authorization required
 
 <a id="rejectoauth2consentrequest"></a>
 # **RejectOAuth2ConsentRequest**
-> ClientOAuth2RedirectTo RejectOAuth2ConsentRequest (string consentChallenge, ClientRejectOAuth2Request clientRejectOAuth2Request = null)
+> Task&lt;IRejectOAuth2ConsentRequestApiResponse&gt; RejectOAuth2ConsentRequestAsync(string consentChallenge, Option<ClientRejectOAuth2Request> clientRejectOAuth2Request = default, System.Threading.CancellationToken cancellationToken = default)
 
 Reject OAuth 2.0 Consent Request
 
 When an authorization code, hybrid, or implicit OAuth 2.0 Flow is initiated, Ory asks the login provider to authenticate the subject and then tell Ory now about it. If the subject authenticated, he/she must now be asked if the OAuth 2.0 Client which initiated the flow should be allowed to access the resources on the subject's behalf.  The consent challenge is appended to the consent provider's URL to which the subject's user-agent (browser) is redirected to. The consent provider uses that challenge to fetch information on the OAuth2 request and then tells Ory if the subject accepted or rejected the request.  This endpoint tells Ory that the subject has not authorized the OAuth 2.0 client to access resources on his/her behalf. The consent provider must include a reason why the consent was not granted.  The response contains a redirect URL which the consent provider should redirect the user-agent to.  The default consent provider is available via the Ory Managed Account Experience. To customize the consent provider, please head over to the OAuth 2.0 documentation.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class RejectOAuth2ConsentRequestExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IOAuth2Api>();
+            string consentChallenge = default!; // OAuth 2.0 Consent Request Challenge
+            Option<ClientRejectOAuth2Request> clientRejectOAuth2Request = default!; //  (optional)
+            var response = await api.RejectOAuth2ConsentRequestAsync(consentChallenge, clientRejectOAuth2Request);
+            ClientOAuth2RedirectTo? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
 | **consentChallenge** | **string** | OAuth 2.0 Consent Request Challenge |  |
-| **clientRejectOAuth2Request** | [**ClientRejectOAuth2Request**](ClientRejectOAuth2Request.md) |  | [optional]  |
+| **clientRejectOAuth2Request** | [**ClientRejectOAuth2Request**](../models/ClientRejectOAuth2Request.md) |  | [optional]  |
 
 ### Return type
 
-[**ClientOAuth2RedirectTo**](ClientOAuth2RedirectTo.md)
+[**ClientOAuth2RedirectTo**](../models/ClientOAuth2RedirectTo.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -939,27 +1759,62 @@ When an authorization code, hybrid, or implicit OAuth 2.0 Flow is initiated, Ory
 
 <a id="rejectoauth2loginrequest"></a>
 # **RejectOAuth2LoginRequest**
-> ClientOAuth2RedirectTo RejectOAuth2LoginRequest (string loginChallenge, ClientRejectOAuth2Request clientRejectOAuth2Request = null)
+> Task&lt;IRejectOAuth2LoginRequestApiResponse&gt; RejectOAuth2LoginRequestAsync(string loginChallenge, Option<ClientRejectOAuth2Request> clientRejectOAuth2Request = default, System.Threading.CancellationToken cancellationToken = default)
 
 Reject OAuth 2.0 Login Request
 
 When an authorization code, hybrid, or implicit OAuth 2.0 Flow is initiated, Ory asks the login provider to authenticate the subject and then tell the Ory OAuth2 Service about it.  The authentication challenge is appended to the login provider URL to which the subject's user-agent (browser) is redirected to. The login provider uses that challenge to fetch information on the OAuth2 request and then accept or reject the requested authentication process.  This endpoint tells Ory that the subject has not authenticated and includes a reason why the authentication was denied.  The response contains a redirect URL which the login provider should redirect the user-agent to.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class RejectOAuth2LoginRequestExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IOAuth2Api>();
+            string loginChallenge = default!; // OAuth 2.0 Login Request Challenge
+            Option<ClientRejectOAuth2Request> clientRejectOAuth2Request = default!; //  (optional)
+            var response = await api.RejectOAuth2LoginRequestAsync(loginChallenge, clientRejectOAuth2Request);
+            ClientOAuth2RedirectTo? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
 | **loginChallenge** | **string** | OAuth 2.0 Login Request Challenge |  |
-| **clientRejectOAuth2Request** | [**ClientRejectOAuth2Request**](ClientRejectOAuth2Request.md) |  | [optional]  |
+| **clientRejectOAuth2Request** | [**ClientRejectOAuth2Request**](../models/ClientRejectOAuth2Request.md) |  | [optional]  |
 
 ### Return type
 
-[**ClientOAuth2RedirectTo**](ClientOAuth2RedirectTo.md)
+[**ClientOAuth2RedirectTo**](../models/ClientOAuth2RedirectTo.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -977,12 +1832,45 @@ When an authorization code, hybrid, or implicit OAuth 2.0 Flow is initiated, Ory
 
 <a id="rejectoauth2logoutrequest"></a>
 # **RejectOAuth2LogoutRequest**
-> void RejectOAuth2LogoutRequest (string logoutChallenge)
+> Task&lt;IRejectOAuth2LogoutRequestApiResponse&gt; RejectOAuth2LogoutRequestAsync(string logoutChallenge, System.Threading.CancellationToken cancellationToken = default)
 
 Reject OAuth 2.0 Session Logout Request
 
 When a user or an application requests Ory OAuth 2.0 to remove the session state of a subject, this endpoint is used to deny that logout request. No HTTP request body is required.  The response is empty as the logout provider has to chose what action to perform next.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class RejectOAuth2LogoutRequestExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IOAuth2Api>();
+            string logoutChallenge = default!; // 
+            await api.RejectOAuth2LogoutRequestAsync(logoutChallenge);
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -996,7 +1884,7 @@ void (empty response body)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -1014,12 +1902,48 @@ void (empty response body)
 
 <a id="revokeoauth2consentsessions"></a>
 # **RevokeOAuth2ConsentSessions**
-> void RevokeOAuth2ConsentSessions (string subject = null, string varClient = null, string consentRequestId = null, bool all = null)
+> Task&lt;IRevokeOAuth2ConsentSessionsApiResponse&gt; RevokeOAuth2ConsentSessionsAsync(Option<string> subject = default, Option<string> varClient = default, Option<string> consentRequestId = default, Option<bool> all = default, System.Threading.CancellationToken cancellationToken = default)
 
 Revoke OAuth 2.0 Consent Sessions of a Subject
 
 This endpoint revokes a subject's granted consent sessions and invalidates all associated OAuth 2.0 Access Tokens. You may also only revoke sessions for a specific OAuth 2.0 Client ID.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class RevokeOAuth2ConsentSessionsExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IOAuth2Api>();
+            Option<string> subject = default!; // OAuth 2.0 Consent Subject  The subject whose consent sessions should be deleted. (optional)
+            Option<string> varClient = default!; // OAuth 2.0 Client ID  If set, deletes only those consent sessions that have been granted to the specified OAuth 2.0 Client ID. (optional)
+            Option<string> consentRequestId = default!; // Consent Request ID  If set, revoke all token chains derived from this particular consent request ID. (optional)
+            Option<bool> all = default!; // Revoke All Consent Sessions  If set to `true` deletes all consent sessions by the Subject that have been granted. (optional)
+            await api.RevokeOAuth2ConsentSessionsAsync(subject, varClient, consentRequestId, all);
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -1036,7 +1960,7 @@ void (empty response body)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -1054,12 +1978,46 @@ void (empty response body)
 
 <a id="revokeoauth2loginsessions"></a>
 # **RevokeOAuth2LoginSessions**
-> void RevokeOAuth2LoginSessions (string subject = null, string sid = null)
+> Task&lt;IRevokeOAuth2LoginSessionsApiResponse&gt; RevokeOAuth2LoginSessionsAsync(Option<string> subject = default, Option<string> sid = default, System.Threading.CancellationToken cancellationToken = default)
 
 Revokes OAuth 2.0 Login Sessions by either a Subject or a SessionID
 
 This endpoint invalidates authentication sessions. After revoking the authentication session(s), the subject has to re-authenticate at the Ory OAuth2 Provider. This endpoint does not invalidate any tokens.  If you send the subject in a query param, all authentication sessions that belong to that subject are revoked. No OpenID Connect Front- or Back-channel logout is performed in this case.  Alternatively, you can send a SessionID via `sid` query param, in which case, only the session that is connected to that SessionID is revoked. OpenID Connect Back-channel logout is performed in this case.  When using Ory for the identity provider, the login provider will also invalidate the session cookie.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class RevokeOAuth2LoginSessionsExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IOAuth2Api>();
+            Option<string> subject = default!; // OAuth 2.0 Subject  The subject to revoke authentication sessions for. (optional)
+            Option<string> sid = default!; // Login Session ID  The login session to revoke. (optional)
+            await api.RevokeOAuth2LoginSessionsAsync(subject, sid);
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -1074,7 +2032,7 @@ void (empty response body)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -1092,12 +2050,47 @@ void (empty response body)
 
 <a id="revokeoauth2token"></a>
 # **RevokeOAuth2Token**
-> void RevokeOAuth2Token (string token, string clientId = null, string clientSecret = null)
+> Task&lt;IRevokeOAuth2TokenApiResponse&gt; RevokeOAuth2TokenAsync(string token, Option<string> clientId = default, Option<string> clientSecret = default, System.Threading.CancellationToken cancellationToken = default)
 
 Revoke OAuth 2.0 Access or Refresh Token
 
 Revoking a token (both access and refresh) means that the tokens will be invalid. A revoked access token can no longer be used to make access requests, and a revoked refresh token can no longer be used to refresh an access token. Revoking a refresh token also invalidates the access token that was created with it. A token may only be revoked by the client the token was generated for.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class RevokeOAuth2TokenExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IOAuth2Api>();
+            string token = default!; // 
+            Option<string> clientId = default!; //  (optional)
+            Option<string> clientSecret = default!; //  (optional)
+            await api.RevokeOAuth2TokenAsync(token, clientId, clientSecret);
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -1113,7 +2106,7 @@ void (empty response body)
 
 ### Authorization
 
-[basic](../README.md#basic), [oauth2](../README.md#oauth2)
+[basic](../../README.md#basic), [oauth2](../../README.md#oauth2)
 
 ### HTTP request headers
 
@@ -1131,12 +2124,46 @@ void (empty response body)
 
 <a id="rotateoauth2clientsecret"></a>
 # **RotateOAuth2ClientSecret**
-> ClientOAuth2Client RotateOAuth2ClientSecret (string id)
+> Task&lt;IRotateOAuth2ClientSecretApiResponse&gt; RotateOAuth2ClientSecretAsync(string id, System.Threading.CancellationToken cancellationToken = default)
 
 Rotate OAuth 2.0 Client Secret
 
 Rotates an OAuth 2.0 client's secrets. The old secret will remain valid for authentication, allowing for zero-downtime secret rotations. A new secret will be generated and returned in the response.  Up to five rotated secrets are retained. Use the `deleteRotatedOAuth2ClientSecrets` endpoint to remove old rotated secrets when they are no longer needed.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class RotateOAuth2ClientSecretExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IOAuth2Api>();
+            string id = default!; // OAuth 2.0 Client ID
+            var response = await api.RotateOAuth2ClientSecretAsync(id);
+            ClientOAuth2Client? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -1146,11 +2173,11 @@ Rotates an OAuth 2.0 client's secrets. The old secret will remain valid for auth
 
 ### Return type
 
-[**ClientOAuth2Client**](ClientOAuth2Client.md)
+[**ClientOAuth2Client**](../models/ClientOAuth2Client.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -1169,27 +2196,62 @@ Rotates an OAuth 2.0 client's secrets. The old secret will remain valid for auth
 
 <a id="setoauth2client"></a>
 # **SetOAuth2Client**
-> ClientOAuth2Client SetOAuth2Client (string id, ClientOAuth2Client clientOAuth2Client)
+> Task&lt;ISetOAuth2ClientApiResponse&gt; SetOAuth2ClientAsync(string id, ClientOAuth2Client clientOAuth2Client, System.Threading.CancellationToken cancellationToken = default)
 
 Set OAuth 2.0 Client
 
 Replaces an existing OAuth 2.0 Client with the payload you send. If you pass `client_secret` the secret is used, otherwise the existing secret is used. Rotated secrets will be cleared if you pass a new `client_secret`.  If set, the secret is echoed in the response. It is not possible to retrieve it later on.  To perform a seamless client secret rotation, use the `rotateOAuth2ClientSecret` endpoint instead.  OAuth 2.0 Clients are used to perform OAuth 2.0 and OpenID Connect flows. Usually, OAuth 2.0 clients are generated for applications which want to consume your OAuth 2.0 or OpenID Connect capabilities.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class SetOAuth2ClientExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IOAuth2Api>();
+            string id = default!; // OAuth 2.0 Client ID
+            ClientOAuth2Client clientOAuth2Client = default!; // OAuth 2.0 Client Request Body
+            var response = await api.SetOAuth2ClientAsync(id, clientOAuth2Client);
+            ClientOAuth2Client? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
 | **id** | **string** | OAuth 2.0 Client ID |  |
-| **clientOAuth2Client** | [**ClientOAuth2Client**](ClientOAuth2Client.md) | OAuth 2.0 Client Request Body |  |
+| **clientOAuth2Client** | [**ClientOAuth2Client**](../models/ClientOAuth2Client.md) | OAuth 2.0 Client Request Body |  |
 
 ### Return type
 
-[**ClientOAuth2Client**](ClientOAuth2Client.md)
+[**ClientOAuth2Client**](../models/ClientOAuth2Client.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -1209,27 +2271,62 @@ Replaces an existing OAuth 2.0 Client with the payload you send. If you pass `cl
 
 <a id="setoauth2clientlifespans"></a>
 # **SetOAuth2ClientLifespans**
-> ClientOAuth2Client SetOAuth2ClientLifespans (string id, ClientOAuth2ClientTokenLifespans clientOAuth2ClientTokenLifespans = null)
+> Task&lt;ISetOAuth2ClientLifespansApiResponse&gt; SetOAuth2ClientLifespansAsync(string id, Option<ClientOAuth2ClientTokenLifespans> clientOAuth2ClientTokenLifespans = default, System.Threading.CancellationToken cancellationToken = default)
 
 Set OAuth2 Client Token Lifespans
 
 Set lifespans of different token types issued for this OAuth 2.0 client. Does not modify other fields.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class SetOAuth2ClientLifespansExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IOAuth2Api>();
+            string id = default!; // OAuth 2.0 Client ID
+            Option<ClientOAuth2ClientTokenLifespans> clientOAuth2ClientTokenLifespans = default!; //  (optional)
+            var response = await api.SetOAuth2ClientLifespansAsync(id, clientOAuth2ClientTokenLifespans);
+            ClientOAuth2Client? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
 | **id** | **string** | OAuth 2.0 Client ID |  |
-| **clientOAuth2ClientTokenLifespans** | [**ClientOAuth2ClientTokenLifespans**](ClientOAuth2ClientTokenLifespans.md) |  | [optional]  |
+| **clientOAuth2ClientTokenLifespans** | [**ClientOAuth2ClientTokenLifespans**](../models/ClientOAuth2ClientTokenLifespans.md) |  | [optional]  |
 
 ### Return type
 
-[**ClientOAuth2Client**](ClientOAuth2Client.md)
+[**ClientOAuth2Client**](../models/ClientOAuth2Client.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -1247,26 +2344,60 @@ Set lifespans of different token types issued for this OAuth 2.0 client. Does no
 
 <a id="trustoauth2jwtgrantissuer"></a>
 # **TrustOAuth2JwtGrantIssuer**
-> ClientTrustedOAuth2JwtGrantIssuer TrustOAuth2JwtGrantIssuer (ClientTrustOAuth2JwtGrantIssuer clientTrustOAuth2JwtGrantIssuer = null)
+> Task&lt;ITrustOAuth2JwtGrantIssuerApiResponse&gt; TrustOAuth2JwtGrantIssuerAsync(Option<ClientTrustOAuth2JwtGrantIssuer> clientTrustOAuth2JwtGrantIssuer = default, System.Threading.CancellationToken cancellationToken = default)
 
 Trust OAuth2 JWT Bearer Grant Type Issuer
 
 Use this endpoint to establish a trust relationship for a JWT issuer to perform JSON Web Token (JWT) Profile for OAuth 2.0 Client Authentication and Authorization Grants [RFC7523](https://datatracker.ietf.org/doc/html/rfc7523).
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class TrustOAuth2JwtGrantIssuerExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IOAuth2Api>();
+            Option<ClientTrustOAuth2JwtGrantIssuer> clientTrustOAuth2JwtGrantIssuer = default!; //  (optional)
+            var response = await api.TrustOAuth2JwtGrantIssuerAsync(clientTrustOAuth2JwtGrantIssuer);
+            ClientTrustedOAuth2JwtGrantIssuer? model = response.Created();
+        }
+    }
+}
+```
 
 ### Parameters
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **clientTrustOAuth2JwtGrantIssuer** | [**ClientTrustOAuth2JwtGrantIssuer**](ClientTrustOAuth2JwtGrantIssuer.md) |  | [optional]  |
+| **clientTrustOAuth2JwtGrantIssuer** | [**ClientTrustOAuth2JwtGrantIssuer**](../models/ClientTrustOAuth2JwtGrantIssuer.md) |  | [optional]  |
 
 ### Return type
 
-[**ClientTrustedOAuth2JwtGrantIssuer**](ClientTrustedOAuth2JwtGrantIssuer.md)
+[**ClientTrustedOAuth2JwtGrantIssuer**](../models/ClientTrustedOAuth2JwtGrantIssuer.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 

--- a/clients/client/dotnet/docs/apis/OidcApi.md
+++ b/clients/client/dotnet/docs/apis/OidcApi.md
@@ -15,22 +15,54 @@ All URIs are relative to *https://playground.projects.oryapis.com*
 
 <a id="createoidcdynamicclient"></a>
 # **CreateOidcDynamicClient**
-> ClientOAuth2Client CreateOidcDynamicClient (ClientOAuth2Client clientOAuth2Client)
+> Task&lt;ICreateOidcDynamicClientApiResponse&gt; CreateOidcDynamicClientAsync(ClientOAuth2Client clientOAuth2Client, System.Threading.CancellationToken cancellationToken = default)
 
 Register OAuth2 Client using OpenID Dynamic Client Registration
 
 This endpoint behaves like the administrative counterpart (`createOAuth2Client`) but is capable of facing the public internet directly and can be used in self-service. It implements the OpenID Connect Dynamic Client Registration Protocol. This feature needs to be enabled in the configuration. This endpoint is disabled by default. It can be enabled by an administrator.  Please note that using this endpoint you are not able to choose the `client_secret` nor the `client_id` as those values will be server generated when specifying `token_endpoint_auth_method` as `client_secret_basic` or `client_secret_post`.  The `client_secret` will be returned in the response and you will not be able to retrieve it later on. Write the secret down and keep it somewhere safe.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class CreateOidcDynamicClientExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IOidcApi>();
+            ClientOAuth2Client clientOAuth2Client = default!; // Dynamic Client Registration Request Body
+            var response = await api.CreateOidcDynamicClientAsync(clientOAuth2Client);
+            ClientOAuth2Client? model = response.Created();
+        }
+    }
+}
+```
 
 ### Parameters
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **clientOAuth2Client** | [**ClientOAuth2Client**](ClientOAuth2Client.md) | Dynamic Client Registration Request Body |  |
+| **clientOAuth2Client** | [**ClientOAuth2Client**](../models/ClientOAuth2Client.md) | Dynamic Client Registration Request Body |  |
 
 ### Return type
 
-[**ClientOAuth2Client**](ClientOAuth2Client.md)
+[**ClientOAuth2Client**](../models/ClientOAuth2Client.md)
 
 ### Authorization
 
@@ -53,22 +85,54 @@ No authorization required
 
 <a id="createverifiablecredential"></a>
 # **CreateVerifiableCredential**
-> ClientVerifiableCredentialResponse CreateVerifiableCredential (ClientCreateVerifiableCredentialRequestBody clientCreateVerifiableCredentialRequestBody = null)
+> Task&lt;ICreateVerifiableCredentialApiResponse&gt; CreateVerifiableCredentialAsync(Option<ClientCreateVerifiableCredentialRequestBody> clientCreateVerifiableCredentialRequestBody = default, System.Threading.CancellationToken cancellationToken = default)
 
 Issues a Verifiable Credential
 
 This endpoint creates a verifiable credential that attests that the user authenticated with the provided access token owns a certain public/private key pair.  More information can be found at https://openid.net/specs/openid-connect-userinfo-vc-1_0.html.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class CreateVerifiableCredentialExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IOidcApi>();
+            Option<ClientCreateVerifiableCredentialRequestBody> clientCreateVerifiableCredentialRequestBody = default!; //  (optional)
+            var response = await api.CreateVerifiableCredentialAsync(clientCreateVerifiableCredentialRequestBody);
+            ClientVerifiableCredentialResponse? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **clientCreateVerifiableCredentialRequestBody** | [**ClientCreateVerifiableCredentialRequestBody**](ClientCreateVerifiableCredentialRequestBody.md) |  | [optional]  |
+| **clientCreateVerifiableCredentialRequestBody** | [**ClientCreateVerifiableCredentialRequestBody**](../models/ClientCreateVerifiableCredentialRequestBody.md) |  | [optional]  |
 
 ### Return type
 
-[**ClientVerifiableCredentialResponse**](ClientVerifiableCredentialResponse.md)
+[**ClientVerifiableCredentialResponse**](../models/ClientVerifiableCredentialResponse.md)
 
 ### Authorization
 
@@ -91,12 +155,45 @@ No authorization required
 
 <a id="deleteoidcdynamicclient"></a>
 # **DeleteOidcDynamicClient**
-> void DeleteOidcDynamicClient (string id)
+> Task&lt;IDeleteOidcDynamicClientApiResponse&gt; DeleteOidcDynamicClientAsync(string id, System.Threading.CancellationToken cancellationToken = default)
 
 Delete OAuth 2.0 Client using the OpenID Dynamic Client Registration Management Protocol
 
 This endpoint behaves like the administrative counterpart (`deleteOAuth2Client`) but is capable of facing the public internet directly and can be used in self-service. It implements the OpenID Connect Dynamic Client Registration Protocol. This feature needs to be enabled in the configuration. This endpoint is disabled by default. It can be enabled by an administrator.  To use this endpoint, you will need to present the client's authentication credentials. If the OAuth2 Client uses the Token Endpoint Authentication Method `client_secret_post`, you need to present the client secret in the URL query. If it uses `client_secret_basic`, present the Client ID and the Client Secret in the Authorization header.  OAuth 2.0 clients are used to perform OAuth 2.0 and OpenID Connect flows. Usually, OAuth 2.0 clients are generated for applications which want to consume your OAuth 2.0 or OpenID Connect capabilities.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class DeleteOidcDynamicClientExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IOidcApi>();
+            string id = default!; // The id of the OAuth 2.0 Client.
+            await api.DeleteOidcDynamicClientAsync(id);
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -110,7 +207,7 @@ void (empty response body)
 
 ### Authorization
 
-[bearer](../README.md#bearer)
+[bearer](../../README.md#bearer)
 
 ### HTTP request headers
 
@@ -128,18 +225,49 @@ void (empty response body)
 
 <a id="discoveroidcconfiguration"></a>
 # **DiscoverOidcConfiguration**
-> ClientOidcConfiguration DiscoverOidcConfiguration ()
+> Task&lt;IDiscoverOidcConfigurationApiResponse&gt; DiscoverOidcConfigurationAsync(System.Threading.CancellationToken cancellationToken = default)
 
 OpenID Connect Discovery
 
 A mechanism for an OpenID Connect Relying Party to discover the End-User's OpenID Provider and obtain information needed to interact with it, including its OAuth 2.0 endpoint locations.  Popular libraries for OpenID Connect clients include oidc-client-js (JavaScript), go-oidc (Golang), and others. For a full list of clients go here: https://openid.net/developers/certified/
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class DiscoverOidcConfigurationExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IOidcApi>();
+            var response = await api.DiscoverOidcConfigurationAsync();
+            ClientOidcConfiguration? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 This endpoint does not need any parameter.
 ### Return type
 
-[**ClientOidcConfiguration**](ClientOidcConfiguration.md)
+[**ClientOidcConfiguration**](../models/ClientOidcConfiguration.md)
 
 ### Authorization
 
@@ -161,12 +289,46 @@ No authorization required
 
 <a id="getoidcdynamicclient"></a>
 # **GetOidcDynamicClient**
-> ClientOAuth2Client GetOidcDynamicClient (string id)
+> Task&lt;IGetOidcDynamicClientApiResponse&gt; GetOidcDynamicClientAsync(string id, System.Threading.CancellationToken cancellationToken = default)
 
 Get OAuth2 Client using OpenID Dynamic Client Registration
 
 This endpoint behaves like the administrative counterpart (`getOAuth2Client`) but is capable of facing the public internet directly and can be used in self-service. It implements the OpenID Connect Dynamic Client Registration Protocol.  To use this endpoint, you will need to present the client's authentication credentials. If the OAuth2 Client uses the Token Endpoint Authentication Method `client_secret_post`, you need to present the client secret in the URL query. If it uses `client_secret_basic`, present the Client ID and the Client Secret in the Authorization header.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class GetOidcDynamicClientExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IOidcApi>();
+            string id = default!; // The id of the OAuth 2.0 Client.
+            var response = await api.GetOidcDynamicClientAsync(id);
+            ClientOAuth2Client? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -176,11 +338,11 @@ This endpoint behaves like the administrative counterpart (`getOAuth2Client`) bu
 
 ### Return type
 
-[**ClientOAuth2Client**](ClientOAuth2Client.md)
+[**ClientOAuth2Client**](../models/ClientOAuth2Client.md)
 
 ### Authorization
 
-[bearer](../README.md#bearer)
+[bearer](../../README.md#bearer)
 
 ### HTTP request headers
 
@@ -198,22 +360,55 @@ This endpoint behaves like the administrative counterpart (`getOAuth2Client`) bu
 
 <a id="getoidcuserinfo"></a>
 # **GetOidcUserInfo**
-> ClientOidcUserInfo GetOidcUserInfo ()
+> Task&lt;IGetOidcUserInfoApiResponse&gt; GetOidcUserInfoAsync(System.Threading.CancellationToken cancellationToken = default)
 
 OpenID Connect Userinfo
 
 This endpoint returns the payload of the ID Token, including `session.id_token` values, of the provided OAuth 2.0 Access Token's consent request.  In the case of authentication error, a WWW-Authenticate header might be set in the response with more information about the error. See [the spec](https://datatracker.ietf.org/doc/html/rfc6750#section-3) for more details about header format.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class GetOidcUserInfoExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IOidcApi>();
+            var response = await api.GetOidcUserInfoAsync();
+            ClientOidcUserInfo? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 This endpoint does not need any parameter.
 ### Return type
 
-[**ClientOidcUserInfo**](ClientOidcUserInfo.md)
+[**ClientOidcUserInfo**](../models/ClientOidcUserInfo.md)
 
 ### Authorization
 
-[oauth2](../README.md#oauth2)
+[oauth2](../../README.md#oauth2)
 
 ### HTTP request headers
 
@@ -231,12 +426,42 @@ This endpoint does not need any parameter.
 
 <a id="revokeoidcsession"></a>
 # **RevokeOidcSession**
-> void RevokeOidcSession ()
+> Task&lt;IRevokeOidcSessionApiResponse&gt; RevokeOidcSessionAsync(System.Threading.CancellationToken cancellationToken = default)
 
 OpenID Connect Front- and Back-channel Enabled Logout
 
 This endpoint initiates and completes user logout at the Ory OAuth2 & OpenID provider and initiates OpenID Connect Front- / Back-channel logout:  https://openid.net/specs/openid-connect-frontchannel-1_0.html https://openid.net/specs/openid-connect-backchannel-1_0.html  Back-channel logout is performed asynchronously and does not affect logout flow.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class RevokeOidcSessionExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IOidcApi>();
+            await api.RevokeOidcSessionAsync();
+        }
+    }
+}
+```
 
 ### Parameters
 This endpoint does not need any parameter.
@@ -263,27 +488,62 @@ No authorization required
 
 <a id="setoidcdynamicclient"></a>
 # **SetOidcDynamicClient**
-> ClientOAuth2Client SetOidcDynamicClient (string id, ClientOAuth2Client clientOAuth2Client)
+> Task&lt;ISetOidcDynamicClientApiResponse&gt; SetOidcDynamicClientAsync(string id, ClientOAuth2Client clientOAuth2Client, System.Threading.CancellationToken cancellationToken = default)
 
 Set OAuth2 Client using OpenID Dynamic Client Registration
 
 This endpoint behaves like the administrative counterpart (`setOAuth2Client`) but is capable of facing the public internet directly to be used by third parties. It implements the OpenID Connect Dynamic Client Registration Protocol.  This feature is disabled per default. It can be enabled by a system administrator.  If you pass `client_secret` the secret is used, otherwise the existing secret is used. If set, the secret is echoed in the response. It is not possible to retrieve it later on.  To use this endpoint, you will need to present the client's authentication credentials. If the OAuth2 Client uses the Token Endpoint Authentication Method `client_secret_post`, you need to present the client secret in the URL query. If it uses `client_secret_basic`, present the Client ID and the Client Secret in the Authorization header.  OAuth 2.0 clients are used to perform OAuth 2.0 and OpenID Connect flows. Usually, OAuth 2.0 clients are generated for applications which want to consume your OAuth 2.0 or OpenID Connect capabilities.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class SetOidcDynamicClientExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IOidcApi>();
+            string id = default!; // OAuth 2.0 Client ID
+            ClientOAuth2Client clientOAuth2Client = default!; // OAuth 2.0 Client Request Body
+            var response = await api.SetOidcDynamicClientAsync(id, clientOAuth2Client);
+            ClientOAuth2Client? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
 | **id** | **string** | OAuth 2.0 Client ID |  |
-| **clientOAuth2Client** | [**ClientOAuth2Client**](ClientOAuth2Client.md) | OAuth 2.0 Client Request Body |  |
+| **clientOAuth2Client** | [**ClientOAuth2Client**](../models/ClientOAuth2Client.md) | OAuth 2.0 Client Request Body |  |
 
 ### Return type
 
-[**ClientOAuth2Client**](ClientOAuth2Client.md)
+[**ClientOAuth2Client**](../models/ClientOAuth2Client.md)
 
 ### Authorization
 
-[bearer](../README.md#bearer)
+[bearer](../../README.md#bearer)
 
 ### HTTP request headers
 

--- a/clients/client/dotnet/docs/apis/PermissionApi.md
+++ b/clients/client/dotnet/docs/apis/PermissionApi.md
@@ -13,27 +13,62 @@ All URIs are relative to *https://playground.projects.oryapis.com*
 
 <a id="batchcheckpermission"></a>
 # **BatchCheckPermission**
-> ClientBatchCheckPermissionResult BatchCheckPermission (long maxDepth = null, ClientBatchCheckPermissionBody clientBatchCheckPermissionBody = null)
+> Task&lt;IBatchCheckPermissionApiResponse&gt; BatchCheckPermissionAsync(Option<long> maxDepth = default, Option<ClientBatchCheckPermissionBody> clientBatchCheckPermissionBody = default, System.Threading.CancellationToken cancellationToken = default)
 
 Batch check permissions
 
 To learn how relationship tuples and the check works, head over to [the documentation](https://www.ory.com/docs/keto/concepts/api-overview).
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class BatchCheckPermissionExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IPermissionApi>();
+            Option<long> maxDepth = default!; //  (optional)
+            Option<ClientBatchCheckPermissionBody> clientBatchCheckPermissionBody = default!; //  (optional)
+            var response = await api.BatchCheckPermissionAsync(maxDepth, clientBatchCheckPermissionBody);
+            ClientBatchCheckPermissionResult? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
 | **maxDepth** | **long** |  | [optional]  |
-| **clientBatchCheckPermissionBody** | [**ClientBatchCheckPermissionBody**](ClientBatchCheckPermissionBody.md) |  | [optional]  |
+| **clientBatchCheckPermissionBody** | [**ClientBatchCheckPermissionBody**](../models/ClientBatchCheckPermissionBody.md) |  | [optional]  |
 
 ### Return type
 
-[**ClientBatchCheckPermissionResult**](ClientBatchCheckPermissionResult.md)
+[**ClientBatchCheckPermissionResult**](../models/ClientBatchCheckPermissionResult.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -52,12 +87,53 @@ To learn how relationship tuples and the check works, head over to [the document
 
 <a id="checkpermission"></a>
 # **CheckPermission**
-> ClientCheckPermissionResult CheckPermission (string varNamespace = null, string varObject = null, string relation = null, string subjectId = null, string subjectSetNamespace = null, string subjectSetObject = null, string subjectSetRelation = null, long maxDepth = null)
+> Task&lt;ICheckPermissionApiResponse&gt; CheckPermissionAsync(Option<string> varNamespace = default, Option<string> varObject = default, Option<string> relation = default, Option<string> subjectId = default, Option<string> subjectSetNamespace = default, Option<string> subjectSetObject = default, Option<string> subjectSetRelation = default, Option<long> maxDepth = default, System.Threading.CancellationToken cancellationToken = default)
 
 Check a permission
 
 To learn how relationship tuples and the check works, head over to [the documentation](https://www.ory.com/docs/keto/concepts/api-overview).
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class CheckPermissionExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IPermissionApi>();
+            Option<string> varNamespace = default!; // Namespace of the Relationship (optional)
+            Option<string> varObject = default!; // Object of the Relationship (optional)
+            Option<string> relation = default!; // Relation of the Relationship (optional)
+            Option<string> subjectId = default!; // SubjectID of the Relationship (optional)
+            Option<string> subjectSetNamespace = default!; // Namespace of the Subject Set (optional)
+            Option<string> subjectSetObject = default!; // Object of the Subject Set (optional)
+            Option<string> subjectSetRelation = default!; // Relation of the Subject Set (optional)
+            Option<long> maxDepth = default!; //  (optional)
+            var response = await api.CheckPermissionAsync(varNamespace, varObject, relation, subjectId, subjectSetNamespace, subjectSetObject, subjectSetRelation, maxDepth);
+            ClientCheckPermissionResult? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -74,11 +150,11 @@ To learn how relationship tuples and the check works, head over to [the document
 
 ### Return type
 
-[**ClientCheckPermissionResult**](ClientCheckPermissionResult.md)
+[**ClientCheckPermissionResult**](../models/ClientCheckPermissionResult.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -97,12 +173,53 @@ To learn how relationship tuples and the check works, head over to [the document
 
 <a id="checkpermissionorerror"></a>
 # **CheckPermissionOrError**
-> ClientCheckPermissionResult CheckPermissionOrError (string varNamespace = null, string varObject = null, string relation = null, string subjectId = null, string subjectSetNamespace = null, string subjectSetObject = null, string subjectSetRelation = null, long maxDepth = null)
+> Task&lt;ICheckPermissionOrErrorApiResponse&gt; CheckPermissionOrErrorAsync(Option<string> varNamespace = default, Option<string> varObject = default, Option<string> relation = default, Option<string> subjectId = default, Option<string> subjectSetNamespace = default, Option<string> subjectSetObject = default, Option<string> subjectSetRelation = default, Option<long> maxDepth = default, System.Threading.CancellationToken cancellationToken = default)
 
 Check a permission
 
 To learn how relationship tuples and the check works, head over to [the documentation](https://www.ory.com/docs/keto/concepts/api-overview).
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class CheckPermissionOrErrorExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IPermissionApi>();
+            Option<string> varNamespace = default!; // Namespace of the Relationship (optional)
+            Option<string> varObject = default!; // Object of the Relationship (optional)
+            Option<string> relation = default!; // Relation of the Relationship (optional)
+            Option<string> subjectId = default!; // SubjectID of the Relationship (optional)
+            Option<string> subjectSetNamespace = default!; // Namespace of the Subject Set (optional)
+            Option<string> subjectSetObject = default!; // Object of the Subject Set (optional)
+            Option<string> subjectSetRelation = default!; // Relation of the Subject Set (optional)
+            Option<long> maxDepth = default!; //  (optional)
+            var response = await api.CheckPermissionOrErrorAsync(varNamespace, varObject, relation, subjectId, subjectSetNamespace, subjectSetObject, subjectSetRelation, maxDepth);
+            ClientCheckPermissionResult? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -119,11 +236,11 @@ To learn how relationship tuples and the check works, head over to [the document
 
 ### Return type
 
-[**ClientCheckPermissionResult**](ClientCheckPermissionResult.md)
+[**ClientCheckPermissionResult**](../models/ClientCheckPermissionResult.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -143,12 +260,49 @@ To learn how relationship tuples and the check works, head over to [the document
 
 <a id="expandpermissions"></a>
 # **ExpandPermissions**
-> ClientExpandedPermissionTree ExpandPermissions (string varNamespace, string varObject, string relation, long maxDepth = null)
+> Task&lt;IExpandPermissionsApiResponse&gt; ExpandPermissionsAsync(string varNamespace, string varObject, string relation, Option<long> maxDepth = default, System.Threading.CancellationToken cancellationToken = default)
 
 Expand a Relationship into permissions.
 
 Use this endpoint to expand a relationship tuple into permissions.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class ExpandPermissionsExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IPermissionApi>();
+            string varNamespace = default!; // Namespace of the Subject Set
+            string varObject = default!; // Object of the Subject Set
+            string relation = default!; // Relation of the Subject Set
+            Option<long> maxDepth = default!; //  (optional)
+            var response = await api.ExpandPermissionsAsync(varNamespace, varObject, relation, maxDepth);
+            ClientExpandedPermissionTree? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -161,11 +315,11 @@ Use this endpoint to expand a relationship tuple into permissions.
 
 ### Return type
 
-[**ClientExpandedPermissionTree**](ClientExpandedPermissionTree.md)
+[**ClientExpandedPermissionTree**](../models/ClientExpandedPermissionTree.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -185,27 +339,62 @@ Use this endpoint to expand a relationship tuple into permissions.
 
 <a id="postcheckpermission"></a>
 # **PostCheckPermission**
-> ClientCheckPermissionResult PostCheckPermission (long maxDepth = null, ClientPostCheckPermissionBody clientPostCheckPermissionBody = null)
+> Task&lt;IPostCheckPermissionApiResponse&gt; PostCheckPermissionAsync(Option<long> maxDepth = default, Option<ClientPostCheckPermissionBody> clientPostCheckPermissionBody = default, System.Threading.CancellationToken cancellationToken = default)
 
 Check a permission
 
 To learn how relationship tuples and the check works, head over to [the documentation](https://www.ory.com/docs/keto/concepts/api-overview).
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class PostCheckPermissionExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IPermissionApi>();
+            Option<long> maxDepth = default!; //  (optional)
+            Option<ClientPostCheckPermissionBody> clientPostCheckPermissionBody = default!; //  (optional)
+            var response = await api.PostCheckPermissionAsync(maxDepth, clientPostCheckPermissionBody);
+            ClientCheckPermissionResult? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
 | **maxDepth** | **long** |  | [optional]  |
-| **clientPostCheckPermissionBody** | [**ClientPostCheckPermissionBody**](ClientPostCheckPermissionBody.md) |  | [optional]  |
+| **clientPostCheckPermissionBody** | [**ClientPostCheckPermissionBody**](../models/ClientPostCheckPermissionBody.md) |  | [optional]  |
 
 ### Return type
 
-[**ClientCheckPermissionResult**](ClientCheckPermissionResult.md)
+[**ClientCheckPermissionResult**](../models/ClientCheckPermissionResult.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -224,27 +413,62 @@ To learn how relationship tuples and the check works, head over to [the document
 
 <a id="postcheckpermissionorerror"></a>
 # **PostCheckPermissionOrError**
-> ClientCheckPermissionResult PostCheckPermissionOrError (long maxDepth = null, ClientPostCheckPermissionOrErrorBody clientPostCheckPermissionOrErrorBody = null)
+> Task&lt;IPostCheckPermissionOrErrorApiResponse&gt; PostCheckPermissionOrErrorAsync(Option<long> maxDepth = default, Option<ClientPostCheckPermissionOrErrorBody> clientPostCheckPermissionOrErrorBody = default, System.Threading.CancellationToken cancellationToken = default)
 
 Check a permission
 
 To learn how relationship tuples and the check works, head over to [the documentation](https://www.ory.com/docs/keto/concepts/api-overview).
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class PostCheckPermissionOrErrorExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IPermissionApi>();
+            Option<long> maxDepth = default!; //  (optional)
+            Option<ClientPostCheckPermissionOrErrorBody> clientPostCheckPermissionOrErrorBody = default!; //  (optional)
+            var response = await api.PostCheckPermissionOrErrorAsync(maxDepth, clientPostCheckPermissionOrErrorBody);
+            ClientCheckPermissionResult? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
 | **maxDepth** | **long** |  | [optional]  |
-| **clientPostCheckPermissionOrErrorBody** | [**ClientPostCheckPermissionOrErrorBody**](ClientPostCheckPermissionOrErrorBody.md) |  | [optional]  |
+| **clientPostCheckPermissionOrErrorBody** | [**ClientPostCheckPermissionOrErrorBody**](../models/ClientPostCheckPermissionOrErrorBody.md) |  | [optional]  |
 
 ### Return type
 
-[**ClientCheckPermissionResult**](ClientCheckPermissionResult.md)
+[**ClientCheckPermissionResult**](../models/ClientCheckPermissionResult.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 

--- a/clients/client/dotnet/docs/apis/ProjectApi.md
+++ b/clients/client/dotnet/docs/apis/ProjectApi.md
@@ -28,27 +28,62 @@ All URIs are relative to *https://playground.projects.oryapis.com*
 
 <a id="createorganization"></a>
 # **CreateOrganization**
-> ClientOrganization CreateOrganization (string projectId, ClientOrganizationBody clientOrganizationBody = null)
+> Task&lt;ICreateOrganizationApiResponse&gt; CreateOrganizationAsync(string projectId, Option<ClientOrganizationBody> clientOrganizationBody = default, System.Threading.CancellationToken cancellationToken = default)
 
 Create an Enterprise SSO Organization
 
 Deprecated: use setProject or patchProjectWithRevision instead  Creates an Enterprise SSO Organization in a project.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class CreateOrganizationExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IProjectApi>();
+            string projectId = default!; // Project ID  The project's ID.
+            Option<ClientOrganizationBody> clientOrganizationBody = default!; //  (optional)
+            var response = await api.CreateOrganizationAsync(projectId, clientOrganizationBody);
+            ClientOrganization? model = response.Created();
+        }
+    }
+}
+```
 
 ### Parameters
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
 | **projectId** | **string** | Project ID  The project&#39;s ID. |  |
-| **clientOrganizationBody** | [**ClientOrganizationBody**](ClientOrganizationBody.md) |  | [optional]  |
+| **clientOrganizationBody** | [**ClientOrganizationBody**](../models/ClientOrganizationBody.md) |  | [optional]  |
 
 ### Return type
 
-[**ClientOrganization**](ClientOrganization.md)
+[**ClientOrganization**](../models/ClientOrganization.md)
 
 ### Authorization
 
-[oryWorkspaceApiKey](../README.md#oryWorkspaceApiKey)
+[oryWorkspaceApiKey](../../README.md#oryWorkspaceApiKey)
 
 ### HTTP request headers
 
@@ -69,12 +104,48 @@ Deprecated: use setProject or patchProjectWithRevision instead  Creates an Enter
 
 <a id="createorganizationonboardingportallink"></a>
 # **CreateOrganizationOnboardingPortalLink**
-> ClientOnboardingPortalLink CreateOrganizationOnboardingPortalLink (string projectId, string organizationId, ClientCreateOrganizationOnboardingPortalLinkBody clientCreateOrganizationOnboardingPortalLinkBody = null)
+> Task&lt;ICreateOrganizationOnboardingPortalLinkApiResponse&gt; CreateOrganizationOnboardingPortalLinkAsync(string projectId, string organizationId, Option<ClientCreateOrganizationOnboardingPortalLinkBody> clientCreateOrganizationOnboardingPortalLinkBody = default, System.Threading.CancellationToken cancellationToken = default)
 
 Create organization onboarding portal link
 
 Create a onboarding portal link for an organization.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class CreateOrganizationOnboardingPortalLinkExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IProjectApi>();
+            string projectId = default!; // Project ID  The project's ID.
+            string organizationId = default!; // Organization ID  The Organization's ID.
+            Option<ClientCreateOrganizationOnboardingPortalLinkBody> clientCreateOrganizationOnboardingPortalLinkBody = default!; //  (optional)
+            var response = await api.CreateOrganizationOnboardingPortalLinkAsync(projectId, organizationId, clientCreateOrganizationOnboardingPortalLinkBody);
+            ClientOnboardingPortalLink? model = response.Created();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -82,15 +153,15 @@ Create a onboarding portal link for an organization.
 |------|------|-------------|-------|
 | **projectId** | **string** | Project ID  The project&#39;s ID. |  |
 | **organizationId** | **string** | Organization ID  The Organization&#39;s ID. |  |
-| **clientCreateOrganizationOnboardingPortalLinkBody** | [**ClientCreateOrganizationOnboardingPortalLinkBody**](ClientCreateOrganizationOnboardingPortalLinkBody.md) |  | [optional]  |
+| **clientCreateOrganizationOnboardingPortalLinkBody** | [**ClientCreateOrganizationOnboardingPortalLinkBody**](../models/ClientCreateOrganizationOnboardingPortalLinkBody.md) |  | [optional]  |
 
 ### Return type
 
-[**ClientOnboardingPortalLink**](ClientOnboardingPortalLink.md)
+[**ClientOnboardingPortalLink**](../models/ClientOnboardingPortalLink.md)
 
 ### Authorization
 
-[oryWorkspaceApiKey](../README.md#oryWorkspaceApiKey)
+[oryWorkspaceApiKey](../../README.md#oryWorkspaceApiKey)
 
 ### HTTP request headers
 
@@ -108,26 +179,60 @@ Create a onboarding portal link for an organization.
 
 <a id="createproject"></a>
 # **CreateProject**
-> ClientProject CreateProject (ClientCreateProjectBody clientCreateProjectBody = null)
+> Task&lt;ICreateProjectApiResponse&gt; CreateProjectAsync(Option<ClientCreateProjectBody> clientCreateProjectBody = default, System.Threading.CancellationToken cancellationToken = default)
 
 Create a Project
 
 Creates a new project.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class CreateProjectExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IProjectApi>();
+            Option<ClientCreateProjectBody> clientCreateProjectBody = default!; //  (optional)
+            var response = await api.CreateProjectAsync(clientCreateProjectBody);
+            ClientProject? model = response.Created();
+        }
+    }
+}
+```
 
 ### Parameters
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **clientCreateProjectBody** | [**ClientCreateProjectBody**](ClientCreateProjectBody.md) |  | [optional]  |
+| **clientCreateProjectBody** | [**ClientCreateProjectBody**](../models/ClientCreateProjectBody.md) |  | [optional]  |
 
 ### Return type
 
-[**ClientProject**](ClientProject.md)
+[**ClientProject**](../models/ClientProject.md)
 
 ### Authorization
 
-[oryWorkspaceApiKey](../README.md#oryWorkspaceApiKey)
+[oryWorkspaceApiKey](../../README.md#oryWorkspaceApiKey)
 
 ### HTTP request headers
 
@@ -149,27 +254,62 @@ Creates a new project.
 
 <a id="createprojectapikey"></a>
 # **CreateProjectApiKey**
-> ClientProjectApiKey CreateProjectApiKey (string project, ClientCreateProjectApiKeyBody clientCreateProjectApiKeyBody = null)
+> Task&lt;ICreateProjectApiKeyApiResponse&gt; CreateProjectApiKeyAsync(string project, Option<ClientCreateProjectApiKeyBody> clientCreateProjectApiKeyBody = default, System.Threading.CancellationToken cancellationToken = default)
 
 Create project API key
 
 Create an API key for a project.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class CreateProjectApiKeyExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IProjectApi>();
+            string project = default!; // The Project ID or Project slug
+            Option<ClientCreateProjectApiKeyBody> clientCreateProjectApiKeyBody = default!; //  (optional)
+            var response = await api.CreateProjectApiKeyAsync(project, clientCreateProjectApiKeyBody);
+            ClientProjectApiKey? model = response.Created();
+        }
+    }
+}
+```
 
 ### Parameters
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
 | **project** | **string** | The Project ID or Project slug |  |
-| **clientCreateProjectApiKeyBody** | [**ClientCreateProjectApiKeyBody**](ClientCreateProjectApiKeyBody.md) |  | [optional]  |
+| **clientCreateProjectApiKeyBody** | [**ClientCreateProjectApiKeyBody**](../models/ClientCreateProjectApiKeyBody.md) |  | [optional]  |
 
 ### Return type
 
-[**ClientProjectApiKey**](ClientProjectApiKey.md)
+[**ClientProjectApiKey**](../models/ClientProjectApiKey.md)
 
 ### Authorization
 
-[oryWorkspaceApiKey](../README.md#oryWorkspaceApiKey)
+[oryWorkspaceApiKey](../../README.md#oryWorkspaceApiKey)
 
 ### HTTP request headers
 
@@ -187,12 +327,46 @@ Create an API key for a project.
 
 <a id="deleteorganization"></a>
 # **DeleteOrganization**
-> void DeleteOrganization (string projectId, string organizationId)
+> Task&lt;IDeleteOrganizationApiResponse&gt; DeleteOrganizationAsync(string projectId, string organizationId, System.Threading.CancellationToken cancellationToken = default)
 
 Delete Enterprise SSO Organization
 
 Deprecated: use setProject or patchProjectWithRevision instead  Irrecoverably deletes an Enterprise SSO Organization in a project by its ID.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class DeleteOrganizationExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IProjectApi>();
+            string projectId = default!; // Project ID  The project's ID.
+            string organizationId = default!; // Organization ID  The Organization's ID.
+            await api.DeleteOrganizationAsync(projectId, organizationId);
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -207,7 +381,7 @@ void (empty response body)
 
 ### Authorization
 
-[oryWorkspaceApiKey](../README.md#oryWorkspaceApiKey)
+[oryWorkspaceApiKey](../../README.md#oryWorkspaceApiKey)
 
 ### HTTP request headers
 
@@ -229,12 +403,47 @@ void (empty response body)
 
 <a id="deleteorganizationonboardingportallink"></a>
 # **DeleteOrganizationOnboardingPortalLink**
-> void DeleteOrganizationOnboardingPortalLink (string projectId, string organizationId, string onboardingPortalLinkId)
+> Task&lt;IDeleteOrganizationOnboardingPortalLinkApiResponse&gt; DeleteOrganizationOnboardingPortalLinkAsync(string projectId, string organizationId, string onboardingPortalLinkId, System.Threading.CancellationToken cancellationToken = default)
 
 Delete an organization onboarding portal link
 
 Deletes a onboarding portal link for an organization.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class DeleteOrganizationOnboardingPortalLinkExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IProjectApi>();
+            string projectId = default!; // 
+            string organizationId = default!; // 
+            string onboardingPortalLinkId = default!; // 
+            await api.DeleteOrganizationOnboardingPortalLinkAsync(projectId, organizationId, onboardingPortalLinkId);
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -250,7 +459,7 @@ void (empty response body)
 
 ### Authorization
 
-[oryWorkspaceApiKey](../README.md#oryWorkspaceApiKey)
+[oryWorkspaceApiKey](../../README.md#oryWorkspaceApiKey)
 
 ### HTTP request headers
 
@@ -270,12 +479,46 @@ void (empty response body)
 
 <a id="deleteprojectapikey"></a>
 # **DeleteProjectApiKey**
-> void DeleteProjectApiKey (string project, string tokenId)
+> Task&lt;IDeleteProjectApiKeyApiResponse&gt; DeleteProjectApiKeyAsync(string project, string tokenId, System.Threading.CancellationToken cancellationToken = default)
 
 Delete project API key
 
 Deletes an API key and immediately removes it.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class DeleteProjectApiKeyExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IProjectApi>();
+            string project = default!; // The Project ID or Project slug
+            string tokenId = default!; // The Token ID
+            await api.DeleteProjectApiKeyAsync(project, tokenId);
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -290,7 +533,7 @@ void (empty response body)
 
 ### Authorization
 
-[oryWorkspaceApiKey](../README.md#oryWorkspaceApiKey)
+[oryWorkspaceApiKey](../../README.md#oryWorkspaceApiKey)
 
 ### HTTP request headers
 
@@ -308,12 +551,47 @@ void (empty response body)
 
 <a id="getorganization"></a>
 # **GetOrganization**
-> ClientGetOrganizationResponse GetOrganization (string projectId, string organizationId)
+> Task&lt;IGetOrganizationApiResponse&gt; GetOrganizationAsync(string projectId, string organizationId, System.Threading.CancellationToken cancellationToken = default)
 
 Get Enterprise SSO Organization by ID
 
 Deprecated: use getProject instead  Retrieves an Enterprise SSO Organization for a project by its ID
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class GetOrganizationExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IProjectApi>();
+            string projectId = default!; // Project ID  The project's ID.
+            string organizationId = default!; // Organization ID  The Organization's ID.
+            var response = await api.GetOrganizationAsync(projectId, organizationId);
+            ClientGetOrganizationResponse? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -324,11 +602,11 @@ Deprecated: use getProject instead  Retrieves an Enterprise SSO Organization for
 
 ### Return type
 
-[**ClientGetOrganizationResponse**](ClientGetOrganizationResponse.md)
+[**ClientGetOrganizationResponse**](../models/ClientGetOrganizationResponse.md)
 
 ### Authorization
 
-[oryWorkspaceApiKey](../README.md#oryWorkspaceApiKey)
+[oryWorkspaceApiKey](../../README.md#oryWorkspaceApiKey)
 
 ### HTTP request headers
 
@@ -349,12 +627,47 @@ Deprecated: use getProject instead  Retrieves an Enterprise SSO Organization for
 
 <a id="getorganizationonboardingportallinks"></a>
 # **GetOrganizationOnboardingPortalLinks**
-> ClientOrganizationOnboardingPortalLinksResponse GetOrganizationOnboardingPortalLinks (string projectId, string organizationId)
+> Task&lt;IGetOrganizationOnboardingPortalLinksApiResponse&gt; GetOrganizationOnboardingPortalLinksAsync(string projectId, string organizationId, System.Threading.CancellationToken cancellationToken = default)
 
 Get the organization onboarding portal links
 
 Retrieves the organization onboarding portal links.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class GetOrganizationOnboardingPortalLinksExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IProjectApi>();
+            string projectId = default!; // Project ID  The project's ID.
+            string organizationId = default!; // Organization ID  The Organization's ID.
+            var response = await api.GetOrganizationOnboardingPortalLinksAsync(projectId, organizationId);
+            ClientOrganizationOnboardingPortalLinksResponse? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -365,11 +678,11 @@ Retrieves the organization onboarding portal links.
 
 ### Return type
 
-[**ClientOrganizationOnboardingPortalLinksResponse**](ClientOrganizationOnboardingPortalLinksResponse.md)
+[**ClientOrganizationOnboardingPortalLinksResponse**](../models/ClientOrganizationOnboardingPortalLinksResponse.md)
 
 ### Authorization
 
-[oryWorkspaceApiKey](../README.md#oryWorkspaceApiKey)
+[oryWorkspaceApiKey](../../README.md#oryWorkspaceApiKey)
 
 ### HTTP request headers
 
@@ -389,12 +702,46 @@ Retrieves the organization onboarding portal links.
 
 <a id="getproject"></a>
 # **GetProject**
-> ClientProject GetProject (string projectId)
+> Task&lt;IGetProjectApiResponse&gt; GetProjectAsync(string projectId, System.Threading.CancellationToken cancellationToken = default)
 
 Get a Project
 
 Get a project you have access to by its ID.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class GetProjectExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IProjectApi>();
+            string projectId = default!; // Project ID  The project's ID.
+            var response = await api.GetProjectAsync(projectId);
+            ClientProject? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -404,11 +751,11 @@ Get a project you have access to by its ID.
 
 ### Return type
 
-[**ClientProject**](ClientProject.md)
+[**ClientProject**](../models/ClientProject.md)
 
 ### Authorization
 
-[oryWorkspaceApiKey](../README.md#oryWorkspaceApiKey)
+[oryWorkspaceApiKey](../../README.md#oryWorkspaceApiKey)
 
 ### HTTP request headers
 
@@ -429,12 +776,46 @@ Get a project you have access to by its ID.
 
 <a id="getprojectmembers"></a>
 # **GetProjectMembers**
-> List&lt;ClientProjectMember&gt; GetProjectMembers (string project)
+> Task&lt;IGetProjectMembersApiResponse&gt; GetProjectMembersAsync(string project, System.Threading.CancellationToken cancellationToken = default)
 
 Get all members associated with this project
 
 This endpoint requires the user to be a member of the project with the role `OWNER` or `DEVELOPER`.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class GetProjectMembersExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IProjectApi>();
+            string project = default!; // 
+            var response = await api.GetProjectMembersAsync(project);
+            List<ClientProjectMember>? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -444,11 +825,11 @@ This endpoint requires the user to be a member of the project with the role `OWN
 
 ### Return type
 
-[**List&lt;ClientProjectMember&gt;**](ClientProjectMember.md)
+[**List&lt;ClientProjectMember&gt;**](../models/ClientProjectMember.md)
 
 ### Authorization
 
-[oryWorkspaceApiKey](../README.md#oryWorkspaceApiKey)
+[oryWorkspaceApiKey](../../README.md#oryWorkspaceApiKey)
 
 ### HTTP request headers
 
@@ -468,12 +849,49 @@ This endpoint requires the user to be a member of the project with the role `OWN
 
 <a id="listorganizations"></a>
 # **ListOrganizations**
-> ClientListOrganizationsResponse ListOrganizations (string projectId, long pageSize = null, string pageToken = null, string domain = null)
+> Task&lt;IListOrganizationsApiResponse&gt; ListOrganizationsAsync(string projectId, Option<long> pageSize = default, Option<string> pageToken = default, Option<string> domain = default, System.Threading.CancellationToken cancellationToken = default)
 
 List all Enterprise SSO organizations
 
 Deprecated: use getProject instead  Lists all Enterprise SSO organizations in a project.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class ListOrganizationsExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IProjectApi>();
+            string projectId = default!; // Project ID  The project's ID.
+            Option<long> pageSize = default!; // Items per Page  This is the number of items per page to return. For details on pagination please head over to the [pagination documentation](https://www.ory.com/docs/ecosystem/api-design#pagination). (optional)
+            Option<string> pageToken = default!; // Next Page Token  The next page token. For details on pagination please head over to the [pagination documentation](https://www.ory.com/docs/ecosystem/api-design#pagination). (optional)
+            Option<string> domain = default!; // Domain  If set, only organizations with that domain will be returned. (optional)
+            var response = await api.ListOrganizationsAsync(projectId, pageSize, pageToken, domain);
+            ClientListOrganizationsResponse? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -486,11 +904,11 @@ Deprecated: use getProject instead  Lists all Enterprise SSO organizations in a 
 
 ### Return type
 
-[**ClientListOrganizationsResponse**](ClientListOrganizationsResponse.md)
+[**ClientListOrganizationsResponse**](../models/ClientListOrganizationsResponse.md)
 
 ### Authorization
 
-[oryWorkspaceApiKey](../README.md#oryWorkspaceApiKey)
+[oryWorkspaceApiKey](../../README.md#oryWorkspaceApiKey)
 
 ### HTTP request headers
 
@@ -510,12 +928,46 @@ Deprecated: use getProject instead  Lists all Enterprise SSO organizations in a 
 
 <a id="listprojectapikeys"></a>
 # **ListProjectApiKeys**
-> List&lt;ClientProjectApiKey&gt; ListProjectApiKeys (string project)
+> Task&lt;IListProjectApiKeysApiResponse&gt; ListProjectApiKeysAsync(string project, System.Threading.CancellationToken cancellationToken = default)
 
 List a project's API keys
 
 A list of all the project's API keys.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class ListProjectApiKeysExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IProjectApi>();
+            string project = default!; // The Project ID or Project slug
+            var response = await api.ListProjectApiKeysAsync(project);
+            List<ClientProjectApiKey>? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -525,11 +977,11 @@ A list of all the project's API keys.
 
 ### Return type
 
-[**List&lt;ClientProjectApiKey&gt;**](ClientProjectApiKey.md)
+[**List&lt;ClientProjectApiKey&gt;**](../models/ClientProjectApiKey.md)
 
 ### Authorization
 
-[oryWorkspaceApiKey](../README.md#oryWorkspaceApiKey)
+[oryWorkspaceApiKey](../../README.md#oryWorkspaceApiKey)
 
 ### HTTP request headers
 
@@ -547,22 +999,55 @@ A list of all the project's API keys.
 
 <a id="listprojects"></a>
 # **ListProjects**
-> List&lt;ClientProjectMetadata&gt; ListProjects ()
+> Task&lt;IListProjectsApiResponse&gt; ListProjectsAsync(System.Threading.CancellationToken cancellationToken = default)
 
 List All Projects
 
 Lists all projects you have access to.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class ListProjectsExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IProjectApi>();
+            var response = await api.ListProjectsAsync();
+            List<ClientProjectMetadata>? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 This endpoint does not need any parameter.
 ### Return type
 
-[**List&lt;ClientProjectMetadata&gt;**](ClientProjectMetadata.md)
+[**List&lt;ClientProjectMetadata&gt;**](../models/ClientProjectMetadata.md)
 
 ### Authorization
 
-[oryWorkspaceApiKey](../README.md#oryWorkspaceApiKey)
+[oryWorkspaceApiKey](../../README.md#oryWorkspaceApiKey)
 
 ### HTTP request headers
 
@@ -583,27 +1068,62 @@ This endpoint does not need any parameter.
 
 <a id="patchproject"></a>
 # **PatchProject**
-> ClientSuccessfulProjectUpdate PatchProject (string projectId, List<ClientJsonPatch> clientJsonPatch = null)
+> Task&lt;IPatchProjectApiResponse&gt; PatchProjectAsync(string projectId, Option<List<ClientJsonPatch>> clientJsonPatch = default, System.Threading.CancellationToken cancellationToken = default)
 
 Patch an Ory Network Project Configuration
 
 Deprecated: Use the `patchProjectWithRevision` endpoint instead to specify the exact revision the patch was generated for.  This endpoints allows you to patch individual Ory Network project configuration keys for Ory's services (identity, permission, ...). The configuration format is fully compatible with the open source projects for the respective services (e.g. Ory Kratos for Identity, Ory Keto for Permissions).  This endpoint expects the `version` key to be set in the payload. If it is unset, it will try to import the config as if it is from the most recent version.  If you have an older version of a configuration, you should set the version key in the payload!  While this endpoint is able to process all configuration items related to features (e.g. password reset), it does not support operational configuration items (e.g. port, tracing, logging) otherwise available in the open source.  For configuration items that can not be translated to the Ory Network, this endpoint will return a list of warnings to help you understand which parts of your config could not be processed.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class PatchProjectExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IProjectApi>();
+            string projectId = default!; // Project ID  The project's ID.
+            Option<List<ClientJsonPatch>> clientJsonPatch = default!; //  (optional)
+            var response = await api.PatchProjectAsync(projectId, clientJsonPatch);
+            ClientSuccessfulProjectUpdate? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
 | **projectId** | **string** | Project ID  The project&#39;s ID. |  |
-| **clientJsonPatch** | [**List&lt;ClientJsonPatch&gt;**](ClientJsonPatch.md) |  | [optional]  |
+| **clientJsonPatch** | [**List&lt;ClientJsonPatch&gt;**](../models/ClientJsonPatch.md) |  | [optional]  |
 
 ### Return type
 
-[**ClientSuccessfulProjectUpdate**](ClientSuccessfulProjectUpdate.md)
+[**ClientSuccessfulProjectUpdate**](../models/ClientSuccessfulProjectUpdate.md)
 
 ### Authorization
 
-[oryWorkspaceApiKey](../README.md#oryWorkspaceApiKey)
+[oryWorkspaceApiKey](../../README.md#oryWorkspaceApiKey)
 
 ### HTTP request headers
 
@@ -625,12 +1145,48 @@ Deprecated: Use the `patchProjectWithRevision` endpoint instead to specify the e
 
 <a id="patchprojectwithrevision"></a>
 # **PatchProjectWithRevision**
-> ClientSuccessfulProjectUpdate PatchProjectWithRevision (string projectId, string revisionId, List<ClientJsonPatch> clientJsonPatch = null)
+> Task&lt;IPatchProjectWithRevisionApiResponse&gt; PatchProjectWithRevisionAsync(string projectId, string revisionId, Option<List<ClientJsonPatch>> clientJsonPatch = default, System.Threading.CancellationToken cancellationToken = default)
 
 Patch an Ory Network Project Configuration based on a revision ID
 
 This endpoints allows you to patch individual Ory Network Project configuration keys for Ory's services (identity, permission, ...). The configuration format is fully compatible with the open source projects for the respective services (e.g. Ory Kratos for Identity, Ory Keto for Permissions).  This endpoint expects the `version` key to be set in the payload. If it is unset, it will try to import the config as if it is from the most recent version.  If you have an older version of a configuration, you should set the version key in the payload!  While this endpoint is able to process all configuration items related to features (e.g. password reset), it does not support operational configuration items (e.g. port, tracing, logging) otherwise available in the open source.  For configuration items that can not be translated to the Ory Network, this endpoint will return a list of warnings to help you understand which parts of your config could not be processed.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class PatchProjectWithRevisionExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IProjectApi>();
+            string projectId = default!; // Project ID  The project's ID.
+            string revisionId = default!; // Revision ID  The revision ID that this patch was generated for.
+            Option<List<ClientJsonPatch>> clientJsonPatch = default!; //  (optional)
+            var response = await api.PatchProjectWithRevisionAsync(projectId, revisionId, clientJsonPatch);
+            ClientSuccessfulProjectUpdate? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -638,15 +1194,15 @@ This endpoints allows you to patch individual Ory Network Project configuration 
 |------|------|-------------|-------|
 | **projectId** | **string** | Project ID  The project&#39;s ID. |  |
 | **revisionId** | **string** | Revision ID  The revision ID that this patch was generated for. |  |
-| **clientJsonPatch** | [**List&lt;ClientJsonPatch&gt;**](ClientJsonPatch.md) |  | [optional]  |
+| **clientJsonPatch** | [**List&lt;ClientJsonPatch&gt;**](../models/ClientJsonPatch.md) |  | [optional]  |
 
 ### Return type
 
-[**ClientSuccessfulProjectUpdate**](ClientSuccessfulProjectUpdate.md)
+[**ClientSuccessfulProjectUpdate**](../models/ClientSuccessfulProjectUpdate.md)
 
 ### Authorization
 
-[oryWorkspaceApiKey](../README.md#oryWorkspaceApiKey)
+[oryWorkspaceApiKey](../../README.md#oryWorkspaceApiKey)
 
 ### HTTP request headers
 
@@ -669,12 +1225,45 @@ This endpoints allows you to patch individual Ory Network Project configuration 
 
 <a id="purgeproject"></a>
 # **PurgeProject**
-> void PurgeProject (string projectId)
+> Task&lt;IPurgeProjectApiResponse&gt; PurgeProjectAsync(string projectId, System.Threading.CancellationToken cancellationToken = default)
 
 Irrecoverably purge a project
 
 !! Use with extreme caution !!  Using this API endpoint you can purge (completely delete) a project and its data. This action can not be undone and will delete ALL your data.  Calling this endpoint will additionally delete custom domains and other related data.  If the project is linked to a subscription, the subscription needs to be unlinked first.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class PurgeProjectExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IProjectApi>();
+            string projectId = default!; // Project ID  The project's ID.
+            await api.PurgeProjectAsync(projectId);
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -688,7 +1277,7 @@ void (empty response body)
 
 ### Authorization
 
-[oryWorkspaceApiKey](../README.md#oryWorkspaceApiKey)
+[oryWorkspaceApiKey](../../README.md#oryWorkspaceApiKey)
 
 ### HTTP request headers
 
@@ -709,12 +1298,46 @@ void (empty response body)
 
 <a id="removeprojectmember"></a>
 # **RemoveProjectMember**
-> void RemoveProjectMember (string project, string member)
+> Task&lt;IRemoveProjectMemberApiResponse&gt; RemoveProjectMemberAsync(string project, string member, System.Threading.CancellationToken cancellationToken = default)
 
 Remove a member associated with this project
 
 This also sets their invite status to `REMOVED`. This endpoint requires the user to be a member of the project with the role `OWNER`.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class RemoveProjectMemberExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IProjectApi>();
+            string project = default!; // 
+            string member = default!; // 
+            await api.RemoveProjectMemberAsync(project, member);
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -729,7 +1352,7 @@ void (empty response body)
 
 ### Authorization
 
-[oryWorkspaceApiKey](../README.md#oryWorkspaceApiKey)
+[oryWorkspaceApiKey](../../README.md#oryWorkspaceApiKey)
 
 ### HTTP request headers
 
@@ -749,27 +1372,62 @@ void (empty response body)
 
 <a id="setproject"></a>
 # **SetProject**
-> ClientSuccessfulProjectUpdate SetProject (string projectId, ClientSetProject clientSetProject = null)
+> Task&lt;ISetProjectApiResponse&gt; SetProjectAsync(string projectId, Option<ClientSetProject> clientSetProject = default, System.Threading.CancellationToken cancellationToken = default)
 
 Update an Ory Network Project Configuration
 
 This endpoints allows you to update the Ory Network project configuration for individual services (identity, permission, ...). The configuration is fully compatible with the open source projects for the respective services (e.g. Ory Kratos for Identity, Ory Keto for Permissions).  This endpoint expects the `version` key to be set in the payload. If it is unset, it will try to import the config as if it is from the most recent version.  If you have an older version of a configuration, you should set the version key in the payload!  While this endpoint is able to process all configuration items related to features (e.g. password reset), it does not support operational configuration items (e.g. port, tracing, logging) otherwise available in the open source.  For configuration items that can not be translated to the Ory Network, this endpoint will return a list of warnings to help you understand which parts of your config could not be processed.  Be aware that updating any service's configuration will completely override your current configuration for that service!
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class SetProjectExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IProjectApi>();
+            string projectId = default!; // Project ID  The project's ID.
+            Option<ClientSetProject> clientSetProject = default!; //  (optional)
+            var response = await api.SetProjectAsync(projectId, clientSetProject);
+            ClientSuccessfulProjectUpdate? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
 | **projectId** | **string** | Project ID  The project&#39;s ID. |  |
-| **clientSetProject** | [**ClientSetProject**](ClientSetProject.md) |  | [optional]  |
+| **clientSetProject** | [**ClientSetProject**](../models/ClientSetProject.md) |  | [optional]  |
 
 ### Return type
 
-[**ClientSuccessfulProjectUpdate**](ClientSuccessfulProjectUpdate.md)
+[**ClientSuccessfulProjectUpdate**](../models/ClientSuccessfulProjectUpdate.md)
 
 ### Authorization
 
-[oryWorkspaceApiKey](../README.md#oryWorkspaceApiKey)
+[oryWorkspaceApiKey](../../README.md#oryWorkspaceApiKey)
 
 ### HTTP request headers
 
@@ -791,12 +1449,48 @@ This endpoints allows you to update the Ory Network project configuration for in
 
 <a id="updateorganization"></a>
 # **UpdateOrganization**
-> ClientOrganization UpdateOrganization (string projectId, string organizationId, ClientOrganizationBody clientOrganizationBody = null)
+> Task&lt;IUpdateOrganizationApiResponse&gt; UpdateOrganizationAsync(string projectId, string organizationId, Option<ClientOrganizationBody> clientOrganizationBody = default, System.Threading.CancellationToken cancellationToken = default)
 
 Update an Enterprise SSO Organization
 
 Deprecated: use setProject or patchProjectWithRevision instead  Updates an Enterprise SSO Organization in a project by its ID.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class UpdateOrganizationExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IProjectApi>();
+            string projectId = default!; // Project ID  The project's ID.
+            string organizationId = default!; // Organization ID  The Organization's ID.
+            Option<ClientOrganizationBody> clientOrganizationBody = default!; //  (optional)
+            var response = await api.UpdateOrganizationAsync(projectId, organizationId, clientOrganizationBody);
+            ClientOrganization? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -804,15 +1498,15 @@ Deprecated: use setProject or patchProjectWithRevision instead  Updates an Enter
 |------|------|-------------|-------|
 | **projectId** | **string** | Project ID  The project&#39;s ID. |  |
 | **organizationId** | **string** | Organization ID  The Organization&#39;s ID. |  |
-| **clientOrganizationBody** | [**ClientOrganizationBody**](ClientOrganizationBody.md) |  | [optional]  |
+| **clientOrganizationBody** | [**ClientOrganizationBody**](../models/ClientOrganizationBody.md) |  | [optional]  |
 
 ### Return type
 
-[**ClientOrganization**](ClientOrganization.md)
+[**ClientOrganization**](../models/ClientOrganization.md)
 
 ### Authorization
 
-[oryWorkspaceApiKey](../README.md#oryWorkspaceApiKey)
+[oryWorkspaceApiKey](../../README.md#oryWorkspaceApiKey)
 
 ### HTTP request headers
 
@@ -834,12 +1528,49 @@ Deprecated: use setProject or patchProjectWithRevision instead  Updates an Enter
 
 <a id="updateorganizationonboardingportallink"></a>
 # **UpdateOrganizationOnboardingPortalLink**
-> ClientOnboardingPortalLink UpdateOrganizationOnboardingPortalLink (string projectId, string organizationId, string onboardingPortalLinkId, ClientUpdateOrganizationOnboardingPortalLinkBody clientUpdateOrganizationOnboardingPortalLinkBody = null)
+> Task&lt;IUpdateOrganizationOnboardingPortalLinkApiResponse&gt; UpdateOrganizationOnboardingPortalLinkAsync(string projectId, string organizationId, string onboardingPortalLinkId, Option<ClientUpdateOrganizationOnboardingPortalLinkBody> clientUpdateOrganizationOnboardingPortalLinkBody = default, System.Threading.CancellationToken cancellationToken = default)
 
 Update organization onboarding portal link
 
 Update a onboarding portal link for an organization.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class UpdateOrganizationOnboardingPortalLinkExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IProjectApi>();
+            string projectId = default!; // Project ID  The project's ID.
+            string organizationId = default!; // Organization ID  The Organization's ID.
+            string onboardingPortalLinkId = default!; // 
+            Option<ClientUpdateOrganizationOnboardingPortalLinkBody> clientUpdateOrganizationOnboardingPortalLinkBody = default!; //  (optional)
+            var response = await api.UpdateOrganizationOnboardingPortalLinkAsync(projectId, organizationId, onboardingPortalLinkId, clientUpdateOrganizationOnboardingPortalLinkBody);
+            ClientOnboardingPortalLink? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -848,15 +1579,15 @@ Update a onboarding portal link for an organization.
 | **projectId** | **string** | Project ID  The project&#39;s ID. |  |
 | **organizationId** | **string** | Organization ID  The Organization&#39;s ID. |  |
 | **onboardingPortalLinkId** | **string** |  |  |
-| **clientUpdateOrganizationOnboardingPortalLinkBody** | [**ClientUpdateOrganizationOnboardingPortalLinkBody**](ClientUpdateOrganizationOnboardingPortalLinkBody.md) |  | [optional]  |
+| **clientUpdateOrganizationOnboardingPortalLinkBody** | [**ClientUpdateOrganizationOnboardingPortalLinkBody**](../models/ClientUpdateOrganizationOnboardingPortalLinkBody.md) |  | [optional]  |
 
 ### Return type
 
-[**ClientOnboardingPortalLink**](ClientOnboardingPortalLink.md)
+[**ClientOnboardingPortalLink**](../models/ClientOnboardingPortalLink.md)
 
 ### Authorization
 
-[oryWorkspaceApiKey](../README.md#oryWorkspaceApiKey)
+[oryWorkspaceApiKey](../../README.md#oryWorkspaceApiKey)
 
 ### HTTP request headers
 

--- a/clients/client/dotnet/docs/apis/RelationshipApi.md
+++ b/clients/client/dotnet/docs/apis/RelationshipApi.md
@@ -13,12 +13,46 @@ All URIs are relative to *https://playground.projects.oryapis.com*
 
 <a id="checkoplsyntax"></a>
 # **CheckOplSyntax**
-> ClientCheckOplSyntaxResult CheckOplSyntax (string body = null)
+> Task&lt;ICheckOplSyntaxApiResponse&gt; CheckOplSyntaxAsync(Option<string> body = default, System.Threading.CancellationToken cancellationToken = default)
 
 Check the syntax of an OPL file
 
 The OPL file is expected in the body of the request.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class CheckOplSyntaxExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IRelationshipApi>();
+            Option<string> body = default!; //  (optional)
+            var response = await api.CheckOplSyntaxAsync(body);
+            ClientCheckOplSyntaxResult? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -28,11 +62,11 @@ The OPL file is expected in the body of the request.
 
 ### Return type
 
-[**ClientCheckOplSyntaxResult**](ClientCheckOplSyntaxResult.md)
+[**ClientCheckOplSyntaxResult**](../models/ClientCheckOplSyntaxResult.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -51,26 +85,60 @@ The OPL file is expected in the body of the request.
 
 <a id="createrelationship"></a>
 # **CreateRelationship**
-> ClientRelationship CreateRelationship (ClientCreateRelationshipBody clientCreateRelationshipBody = null)
+> Task&lt;ICreateRelationshipApiResponse&gt; CreateRelationshipAsync(Option<ClientCreateRelationshipBody> clientCreateRelationshipBody = default, System.Threading.CancellationToken cancellationToken = default)
 
 Create a Relationship
 
 Use this endpoint to create a relationship.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class CreateRelationshipExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IRelationshipApi>();
+            Option<ClientCreateRelationshipBody> clientCreateRelationshipBody = default!; //  (optional)
+            var response = await api.CreateRelationshipAsync(clientCreateRelationshipBody);
+            ClientRelationship? model = response.Created();
+        }
+    }
+}
+```
 
 ### Parameters
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **clientCreateRelationshipBody** | [**ClientCreateRelationshipBody**](ClientCreateRelationshipBody.md) |  | [optional]  |
+| **clientCreateRelationshipBody** | [**ClientCreateRelationshipBody**](../models/ClientCreateRelationshipBody.md) |  | [optional]  |
 
 ### Return type
 
-[**ClientRelationship**](ClientRelationship.md)
+[**ClientRelationship**](../models/ClientRelationship.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -89,12 +157,51 @@ Use this endpoint to create a relationship.
 
 <a id="deleterelationships"></a>
 # **DeleteRelationships**
-> void DeleteRelationships (string varNamespace = null, string varObject = null, string relation = null, string subjectId = null, string subjectSetNamespace = null, string subjectSetObject = null, string subjectSetRelation = null)
+> Task&lt;IDeleteRelationshipsApiResponse&gt; DeleteRelationshipsAsync(Option<string> varNamespace = default, Option<string> varObject = default, Option<string> relation = default, Option<string> subjectId = default, Option<string> subjectSetNamespace = default, Option<string> subjectSetObject = default, Option<string> subjectSetRelation = default, System.Threading.CancellationToken cancellationToken = default)
 
 Delete Relationships
 
 Use this endpoint to delete relationships
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class DeleteRelationshipsExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IRelationshipApi>();
+            Option<string> varNamespace = default!; // Namespace of the Relationship (optional)
+            Option<string> varObject = default!; // Object of the Relationship (optional)
+            Option<string> relation = default!; // Relation of the Relationship (optional)
+            Option<string> subjectId = default!; // SubjectID of the Relationship (optional)
+            Option<string> subjectSetNamespace = default!; // Namespace of the Subject Set (optional)
+            Option<string> subjectSetObject = default!; // Object of the Subject Set (optional)
+            Option<string> subjectSetRelation = default!; // Relation of the Subject Set (optional)
+            await api.DeleteRelationshipsAsync(varNamespace, varObject, relation, subjectId, subjectSetNamespace, subjectSetObject, subjectSetRelation);
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -114,7 +221,7 @@ void (empty response body)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -133,12 +240,54 @@ void (empty response body)
 
 <a id="getrelationships"></a>
 # **GetRelationships**
-> ClientRelationships GetRelationships (long pageSize = null, string pageToken = null, string varNamespace = null, string varObject = null, string relation = null, string subjectId = null, string subjectSetNamespace = null, string subjectSetObject = null, string subjectSetRelation = null)
+> Task&lt;IGetRelationshipsApiResponse&gt; GetRelationshipsAsync(Option<long> pageSize = default, Option<string> pageToken = default, Option<string> varNamespace = default, Option<string> varObject = default, Option<string> relation = default, Option<string> subjectId = default, Option<string> subjectSetNamespace = default, Option<string> subjectSetObject = default, Option<string> subjectSetRelation = default, System.Threading.CancellationToken cancellationToken = default)
 
 Query relationships
 
 Get all relationships that match the query. Only the namespace field is required.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class GetRelationshipsExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IRelationshipApi>();
+            Option<long> pageSize = default!; // Items per Page  This is the number of items per page to return. For details on pagination please head over to the [pagination documentation](https://www.ory.com/docs/ecosystem/api-design#pagination). (optional)
+            Option<string> pageToken = default!; // Next Page Token  The next page token. For details on pagination please head over to the [pagination documentation](https://www.ory.com/docs/ecosystem/api-design#pagination). (optional)
+            Option<string> varNamespace = default!; // Namespace of the Relationship (optional)
+            Option<string> varObject = default!; // Object of the Relationship (optional)
+            Option<string> relation = default!; // Relation of the Relationship (optional)
+            Option<string> subjectId = default!; // SubjectID of the Relationship (optional)
+            Option<string> subjectSetNamespace = default!; // Namespace of the Subject Set (optional)
+            Option<string> subjectSetObject = default!; // Object of the Subject Set (optional)
+            Option<string> subjectSetRelation = default!; // Relation of the Subject Set (optional)
+            var response = await api.GetRelationshipsAsync(pageSize, pageToken, varNamespace, varObject, relation, subjectId, subjectSetNamespace, subjectSetObject, subjectSetRelation);
+            ClientRelationships? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -156,11 +305,11 @@ Get all relationships that match the query. Only the namespace field is required
 
 ### Return type
 
-[**ClientRelationships**](ClientRelationships.md)
+[**ClientRelationships**](../models/ClientRelationships.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -179,22 +328,55 @@ Get all relationships that match the query. Only the namespace field is required
 
 <a id="listrelationshipnamespaces"></a>
 # **ListRelationshipNamespaces**
-> ClientRelationshipNamespaces ListRelationshipNamespaces ()
+> Task&lt;IListRelationshipNamespacesApiResponse&gt; ListRelationshipNamespacesAsync(System.Threading.CancellationToken cancellationToken = default)
 
 Query namespaces
 
 Get all namespaces
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class ListRelationshipNamespacesExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IRelationshipApi>();
+            var response = await api.ListRelationshipNamespacesAsync();
+            ClientRelationshipNamespaces? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 This endpoint does not need any parameter.
 ### Return type
 
-[**ClientRelationshipNamespaces**](ClientRelationshipNamespaces.md)
+[**ClientRelationshipNamespaces**](../models/ClientRelationshipNamespaces.md)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 
@@ -212,18 +394,51 @@ This endpoint does not need any parameter.
 
 <a id="patchrelationships"></a>
 # **PatchRelationships**
-> void PatchRelationships (List<ClientRelationshipPatch> clientRelationshipPatch = null)
+> Task&lt;IPatchRelationshipsApiResponse&gt; PatchRelationshipsAsync(Option<List<ClientRelationshipPatch>> clientRelationshipPatch = default, System.Threading.CancellationToken cancellationToken = default)
 
 Patch Multiple Relationships
 
 Use this endpoint to patch one or more relationships.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class PatchRelationshipsExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IRelationshipApi>();
+            Option<List<ClientRelationshipPatch>> clientRelationshipPatch = default!; //  (optional)
+            await api.PatchRelationshipsAsync(clientRelationshipPatch);
+        }
+    }
+}
+```
 
 ### Parameters
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **clientRelationshipPatch** | [**List&lt;ClientRelationshipPatch&gt;**](ClientRelationshipPatch.md) |  | [optional]  |
+| **clientRelationshipPatch** | [**List&lt;ClientRelationshipPatch&gt;**](../models/ClientRelationshipPatch.md) |  | [optional]  |
 
 ### Return type
 
@@ -231,7 +446,7 @@ void (empty response body)
 
 ### Authorization
 
-[oryAccessToken](../README.md#oryAccessToken)
+[oryAccessToken](../../README.md#oryAccessToken)
 
 ### HTTP request headers
 

--- a/clients/client/dotnet/docs/apis/WellknownApi.md
+++ b/clients/client/dotnet/docs/apis/WellknownApi.md
@@ -8,18 +8,49 @@ All URIs are relative to *https://playground.projects.oryapis.com*
 
 <a id="discoverjsonwebkeys"></a>
 # **DiscoverJsonWebKeys**
-> ClientJsonWebKeySet DiscoverJsonWebKeys ()
+> Task&lt;IDiscoverJsonWebKeysApiResponse&gt; DiscoverJsonWebKeysAsync(System.Threading.CancellationToken cancellationToken = default)
 
 Discover Well-Known JSON Web Keys
 
 This endpoint returns JSON Web Keys required to verifying OpenID Connect ID Tokens and, if enabled, OAuth 2.0 JWT Access Tokens. This endpoint can be used with client libraries like [node-jwks-rsa](https://github.com/auth0/node-jwks-rsa) among others.  Adding custom keys requires first creating a keyset via the createJsonWebKeySet operation, and then configuring the webfinger.jwks.broadcast_keys configuration value to include the keyset name.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class DiscoverJsonWebKeysExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IWellknownApi>();
+            var response = await api.DiscoverJsonWebKeysAsync();
+            ClientJsonWebKeySet? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 This endpoint does not need any parameter.
 ### Return type
 
-[**ClientJsonWebKeySet**](ClientJsonWebKeySet.md)
+[**ClientJsonWebKeySet**](../models/ClientJsonWebKeySet.md)
 
 ### Authorization
 

--- a/clients/client/dotnet/docs/apis/WorkspaceApi.md
+++ b/clients/client/dotnet/docs/apis/WorkspaceApi.md
@@ -15,24 +15,58 @@ All URIs are relative to *https://playground.projects.oryapis.com*
 
 <a id="createworkspace"></a>
 # **CreateWorkspace**
-> ClientWorkspace CreateWorkspace (ClientCreateWorkspaceBody clientCreateWorkspaceBody = null)
+> Task&lt;ICreateWorkspaceApiResponse&gt; CreateWorkspaceAsync(Option<ClientCreateWorkspaceBody> clientCreateWorkspaceBody = default, System.Threading.CancellationToken cancellationToken = default)
 
 Create a new workspace
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class CreateWorkspaceExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IWorkspaceApi>();
+            Option<ClientCreateWorkspaceBody> clientCreateWorkspaceBody = default!; //  (optional)
+            var response = await api.CreateWorkspaceAsync(clientCreateWorkspaceBody);
+            ClientWorkspace? model = response.Created();
+        }
+    }
+}
+```
 
 ### Parameters
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
-| **clientCreateWorkspaceBody** | [**ClientCreateWorkspaceBody**](ClientCreateWorkspaceBody.md) |  | [optional]  |
+| **clientCreateWorkspaceBody** | [**ClientCreateWorkspaceBody**](../models/ClientCreateWorkspaceBody.md) |  | [optional]  |
 
 ### Return type
 
-[**ClientWorkspace**](ClientWorkspace.md)
+[**ClientWorkspace**](../models/ClientWorkspace.md)
 
 ### Authorization
 
-[oryWorkspaceApiKey](../README.md#oryWorkspaceApiKey)
+[oryWorkspaceApiKey](../../README.md#oryWorkspaceApiKey)
 
 ### HTTP request headers
 
@@ -54,27 +88,62 @@ Create a new workspace
 
 <a id="createworkspaceapikey"></a>
 # **CreateWorkspaceApiKey**
-> ClientWorkspaceApiKey CreateWorkspaceApiKey (string workspace, ClientCreateWorkspaceApiKeyBody clientCreateWorkspaceApiKeyBody = null)
+> Task&lt;ICreateWorkspaceApiKeyApiResponse&gt; CreateWorkspaceApiKeyAsync(string workspace, Option<ClientCreateWorkspaceApiKeyBody> clientCreateWorkspaceApiKeyBody = default, System.Threading.CancellationToken cancellationToken = default)
 
 Create workspace API key
 
 Create an API key for a workspace.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class CreateWorkspaceApiKeyExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IWorkspaceApi>();
+            string workspace = default!; // The Workspace ID
+            Option<ClientCreateWorkspaceApiKeyBody> clientCreateWorkspaceApiKeyBody = default!; //  (optional)
+            var response = await api.CreateWorkspaceApiKeyAsync(workspace, clientCreateWorkspaceApiKeyBody);
+            ClientWorkspaceApiKey? model = response.Created();
+        }
+    }
+}
+```
 
 ### Parameters
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
 | **workspace** | **string** | The Workspace ID |  |
-| **clientCreateWorkspaceApiKeyBody** | [**ClientCreateWorkspaceApiKeyBody**](ClientCreateWorkspaceApiKeyBody.md) |  | [optional]  |
+| **clientCreateWorkspaceApiKeyBody** | [**ClientCreateWorkspaceApiKeyBody**](../models/ClientCreateWorkspaceApiKeyBody.md) |  | [optional]  |
 
 ### Return type
 
-[**ClientWorkspaceApiKey**](ClientWorkspaceApiKey.md)
+[**ClientWorkspaceApiKey**](../models/ClientWorkspaceApiKey.md)
 
 ### Authorization
 
-[oryWorkspaceApiKey](../README.md#oryWorkspaceApiKey)
+[oryWorkspaceApiKey](../../README.md#oryWorkspaceApiKey)
 
 ### HTTP request headers
 
@@ -92,12 +161,46 @@ Create an API key for a workspace.
 
 <a id="deleteworkspaceapikey"></a>
 # **DeleteWorkspaceApiKey**
-> void DeleteWorkspaceApiKey (string workspace, string tokenId)
+> Task&lt;IDeleteWorkspaceApiKeyApiResponse&gt; DeleteWorkspaceApiKeyAsync(string workspace, string tokenId, System.Threading.CancellationToken cancellationToken = default)
 
 Delete workspace API key
 
 Deletes an API key and immediately removes it.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class DeleteWorkspaceApiKeyExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IWorkspaceApi>();
+            string workspace = default!; // The Workspace ID or Workspace slug
+            string tokenId = default!; // The Token ID
+            await api.DeleteWorkspaceApiKeyAsync(workspace, tokenId);
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -112,7 +215,7 @@ void (empty response body)
 
 ### Authorization
 
-[oryWorkspaceApiKey](../README.md#oryWorkspaceApiKey)
+[oryWorkspaceApiKey](../../README.md#oryWorkspaceApiKey)
 
 ### HTTP request headers
 
@@ -130,12 +233,46 @@ void (empty response body)
 
 <a id="getworkspace"></a>
 # **GetWorkspace**
-> ClientWorkspace GetWorkspace (string workspace)
+> Task&lt;IGetWorkspaceApiResponse&gt; GetWorkspaceAsync(string workspace, System.Threading.CancellationToken cancellationToken = default)
 
 Get a workspace
 
 Any workspace member can access this endpoint.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class GetWorkspaceExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IWorkspaceApi>();
+            string workspace = default!; // 
+            var response = await api.GetWorkspaceAsync(workspace);
+            ClientWorkspace? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -145,11 +282,11 @@ Any workspace member can access this endpoint.
 
 ### Return type
 
-[**ClientWorkspace**](ClientWorkspace.md)
+[**ClientWorkspace**](../models/ClientWorkspace.md)
 
 ### Authorization
 
-[oryWorkspaceApiKey](../README.md#oryWorkspaceApiKey)
+[oryWorkspaceApiKey](../../README.md#oryWorkspaceApiKey)
 
 ### HTTP request headers
 
@@ -171,12 +308,46 @@ Any workspace member can access this endpoint.
 
 <a id="listworkspaceapikeys"></a>
 # **ListWorkspaceApiKeys**
-> List&lt;ClientWorkspaceApiKey&gt; ListWorkspaceApiKeys (string workspace)
+> Task&lt;IListWorkspaceApiKeysApiResponse&gt; ListWorkspaceApiKeysAsync(string workspace, System.Threading.CancellationToken cancellationToken = default)
 
 List a workspace's API keys
 
 A list of all the workspace's API keys.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class ListWorkspaceApiKeysExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IWorkspaceApi>();
+            string workspace = default!; // The Workspace ID or Workspace slug
+            var response = await api.ListWorkspaceApiKeysAsync(workspace);
+            List<ClientWorkspaceApiKey>? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -186,11 +357,11 @@ A list of all the workspace's API keys.
 
 ### Return type
 
-[**List&lt;ClientWorkspaceApiKey&gt;**](ClientWorkspaceApiKey.md)
+[**List&lt;ClientWorkspaceApiKey&gt;**](../models/ClientWorkspaceApiKey.md)
 
 ### Authorization
 
-[oryWorkspaceApiKey](../README.md#oryWorkspaceApiKey)
+[oryWorkspaceApiKey](../../README.md#oryWorkspaceApiKey)
 
 ### HTTP request headers
 
@@ -208,12 +379,46 @@ A list of all the workspace's API keys.
 
 <a id="listworkspaceprojects"></a>
 # **ListWorkspaceProjects**
-> ClientListWorkspaceProjects ListWorkspaceProjects (string workspace)
+> Task&lt;IListWorkspaceProjectsApiResponse&gt; ListWorkspaceProjectsAsync(string workspace, System.Threading.CancellationToken cancellationToken = default)
 
 List all projects of a workspace
 
 Any workspace member can access this endpoint.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class ListWorkspaceProjectsExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IWorkspaceApi>();
+            string workspace = default!; // 
+            var response = await api.ListWorkspaceProjectsAsync(workspace);
+            ClientListWorkspaceProjects? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -223,11 +428,11 @@ Any workspace member can access this endpoint.
 
 ### Return type
 
-[**ClientListWorkspaceProjects**](ClientListWorkspaceProjects.md)
+[**ClientListWorkspaceProjects**](../models/ClientListWorkspaceProjects.md)
 
 ### Authorization
 
-[oryWorkspaceApiKey](../README.md#oryWorkspaceApiKey)
+[oryWorkspaceApiKey](../../README.md#oryWorkspaceApiKey)
 
 ### HTTP request headers
 
@@ -249,10 +454,45 @@ Any workspace member can access this endpoint.
 
 <a id="listworkspaces"></a>
 # **ListWorkspaces**
-> ClientListWorkspaces ListWorkspaces (long pageSize = null, string pageToken = null)
+> Task&lt;IListWorkspacesApiResponse&gt; ListWorkspacesAsync(Option<long> pageSize = default, Option<string> pageToken = default, System.Threading.CancellationToken cancellationToken = default)
 
 List workspaces the user is a member of
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class ListWorkspacesExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IWorkspaceApi>();
+            Option<long> pageSize = default!; // Items per Page  This is the number of items per page to return. For details on pagination please head over to the [pagination documentation](https://www.ory.com/docs/ecosystem/api-design#pagination). (optional)
+            Option<string> pageToken = default!; // Next Page Token  The next page token. For details on pagination please head over to the [pagination documentation](https://www.ory.com/docs/ecosystem/api-design#pagination). (optional)
+            var response = await api.ListWorkspacesAsync(pageSize, pageToken);
+            ClientListWorkspaces? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
@@ -263,11 +503,11 @@ List workspaces the user is a member of
 
 ### Return type
 
-[**ClientListWorkspaces**](ClientListWorkspaces.md)
+[**ClientListWorkspaces**](../models/ClientListWorkspaces.md)
 
 ### Authorization
 
-[oryWorkspaceApiKey](../README.md#oryWorkspaceApiKey)
+[oryWorkspaceApiKey](../../README.md#oryWorkspaceApiKey)
 
 ### HTTP request headers
 
@@ -289,27 +529,62 @@ List workspaces the user is a member of
 
 <a id="updateworkspace"></a>
 # **UpdateWorkspace**
-> ClientWorkspace UpdateWorkspace (string workspace, ClientUpdateWorkspaceBody clientUpdateWorkspaceBody = null)
+> Task&lt;IUpdateWorkspaceApiResponse&gt; UpdateWorkspaceAsync(string workspace, Option<ClientUpdateWorkspaceBody> clientUpdateWorkspaceBody = default, System.Threading.CancellationToken cancellationToken = default)
 
 Update an workspace
 
 Workspace members with the role `OWNER` can access this endpoint.
 
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Ory.Client.Api;
+using Ory.Client.Client;
+using Ory.Client.Extensions;
+using Ory.Client.Model;
+
+namespace Example
+{
+    public class UpdateWorkspaceExample
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureApi((context, services, options) =>
+                {
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    options.AddApiHttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<IWorkspaceApi>();
+            string workspace = default!; // 
+            Option<ClientUpdateWorkspaceBody> clientUpdateWorkspaceBody = default!; //  (optional)
+            var response = await api.UpdateWorkspaceAsync(workspace, clientUpdateWorkspaceBody);
+            ClientWorkspace? model = response.Ok();
+        }
+    }
+}
+```
 
 ### Parameters
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
 | **workspace** | **string** |  |  |
-| **clientUpdateWorkspaceBody** | [**ClientUpdateWorkspaceBody**](ClientUpdateWorkspaceBody.md) |  | [optional]  |
+| **clientUpdateWorkspaceBody** | [**ClientUpdateWorkspaceBody**](../models/ClientUpdateWorkspaceBody.md) |  | [optional]  |
 
 ### Return type
 
-[**ClientWorkspace**](ClientWorkspace.md)
+[**ClientWorkspace**](../models/ClientWorkspace.md)
 
 ### Authorization
 
-[oryWorkspaceApiKey](../README.md#oryWorkspaceApiKey)
+[oryWorkspaceApiKey](../../README.md#oryWorkspaceApiKey)
 
 ### HTTP request headers
 

--- a/clients/client/rust/docs/ApiKeysApi.md
+++ b/clients/client/rust/docs/ApiKeysApi.md
@@ -32,6 +32,24 @@ Batch Import API Keys
 
 Imports up to 1000 external API keys in one request. Returns per-item results. If at least one item succeeds, response is 200 OK. If all items fail, the endpoint returns a non-200 error.  ```http POST /v2alpha1/admin/importedApiKeys:batchCreate {   \"requests\": [     {\"raw_key\": \"sk_live_abc\", \"name\": \"Stripe key\", \"actor_id\": \"user_1\"},     {\"raw_key\": \"ghp_xyz\", \"name\": \"GitHub PAT\", \"actor_id\": \"user_2\"}   ] } ```
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::api_keys_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let batch_create_imported_api_keys_request = Default::default(); // BatchCreateImportedApiKeysRequest | BatchCreateImportedApiKeysRequest imports multiple external API keys in one request. The maximum batch size is 1000 keys.
+    match api_keys_api::admin_batch_create_imported_api_keys(&configuration, batch_create_imported_api_keys_request).await {
+        Ok(response) => println!("ApiKeysApi::admin_batch_create_imported_api_keys: {:?}", response),
+        Err(error) => eprintln!("Error calling ApiKeysApi::admin_batch_create_imported_api_keys: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -61,6 +79,26 @@ Name | Type | Description  | Required | Notes
 Batch Verify API Keys
 
 Verifies multiple credentials in a single request. Efficiently verifies up to 100 credentials in parallel. Each credential is verified independently; partial failures are returned. Admin access only.  Cache Control (HTTP Headers):   - Cache-Control: no-cache  - Bypasses cache read, forces fresh DB lookup   - Cache-Control: no-store  - Bypasses cache read AND write (never cached)   - Pragma: no-cache         - Same as Cache-Control: no-cache (HTTP/1.0)  The cache directive applies to every credential in the batch.  ```http POST /v2alpha1/admin/apiKeys:batchVerify {   \"requests\": [     {\"credential\": \"sk_live_abc123...\"},     {\"credential\": \"eyJhbGciOiJFZERTQSI...\"}   ] } ```
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::api_keys_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let batch_verify_api_keys_request = Default::default(); // BatchVerifyApiKeysRequest
+    let cache_control = None; // String | Cache-directive controlling the verifier cache. `no-cache` forces a fresh database lookup (cache read is bypassed). `no-store` additionally prevents the result from being written to the cache. Any other value is ignored. (optional)
+    let pragma = None; // String | HTTP/1.0 alias for `Cache-Control: no-cache`. Behaves identically when set to `no-cache`; ignored otherwise. (optional)
+    match api_keys_api::admin_batch_verify_api_keys(&configuration, batch_verify_api_keys_request, cache_control, pragma).await {
+        Ok(response) => println!("ApiKeysApi::admin_batch_verify_api_keys: {:?}", response),
+        Err(error) => eprintln!("Error calling ApiKeysApi::admin_batch_verify_api_keys: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -94,6 +132,24 @@ Delete Imported API Key
 
 Permanently deletes an imported key (hard delete). The key is removed from the database. Use AdminRevokeImportedApiKey for soft deletion (recommended).  ```http DELETE /v2alpha1/admin/importedApiKeys/{key_id} ```
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::api_keys_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let key_id = "key_id_example"; // String | SHA512/256 hash of the imported key (REQUIRED)
+    match api_keys_api::admin_delete_imported_api_key(&configuration, key_id).await {
+        Ok(_) => println!("ApiKeysApi::admin_delete_imported_api_key"),
+        Err(error) => eprintln!("Error calling ApiKeysApi::admin_delete_imported_api_key: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -123,6 +179,24 @@ Name | Type | Description  | Required | Notes
 Derive Token
 
 Mints a short-lived JWT or Macaroon token from an API key. Works with both issued and imported keys. The derived token inherits the permissions of the parent API key.  ```http POST /v2alpha1/admin/apiKeys:derive {   \"credential\": \"eyJhbGciOiJFZERTQSI...\",   \"ttl\": \"1h\" } ```
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::api_keys_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let derive_token_request = Default::default(); // DeriveTokenRequest
+    match api_keys_api::admin_derive_token(&configuration, derive_token_request).await {
+        Ok(response) => println!("ApiKeysApi::admin_derive_token: {:?}", response),
+        Err(error) => eprintln!("Error calling ApiKeysApi::admin_derive_token: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -154,6 +228,24 @@ Get Imported API Key
 
 Retrieves details about a specific imported key. Returns metadata about the imported key. The original raw key is never returned.  ```http GET /v2alpha1/admin/importedApiKeys/{key_id} ```
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::api_keys_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let key_id = "key_id_example"; // String | SHA512/256 hash of the imported key (REQUIRED)
+    match api_keys_api::admin_get_imported_api_key(&configuration, key_id).await {
+        Ok(response) => println!("ApiKeysApi::admin_get_imported_api_key: {:?}", response),
+        Err(error) => eprintln!("Error calling ApiKeysApi::admin_get_imported_api_key: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -183,6 +275,24 @@ Name | Type | Description  | Required | Notes
 Get Issued API Key
 
 Retrieves details about a specific issued API key including its status, scopes, expiration, and usage statistics. The secret is never returned.  ```http GET /v2alpha1/admin/issuedApiKeys/01HQZX9VYQKJB8XQZQXQZQXQXQ ```
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::api_keys_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let key_id = "key_id_example"; // String | Identifier of the API key resource.
+    match api_keys_api::admin_get_issued_api_key(&configuration, key_id).await {
+        Ok(response) => println!("ApiKeysApi::admin_get_issued_api_key: {:?}", response),
+        Err(error) => eprintln!("Error calling ApiKeysApi::admin_get_issued_api_key: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -214,6 +324,24 @@ Import API Key
 
 Imports an external API key into the system. Allows importing keys from legacy systems or external providers. The raw key is hashed and stored securely (HMAC). Imported keys support token derivation (JWT/Macaroon) like issued keys.  ```http POST /v2alpha1/admin/importedApiKeys {   \"raw_key\": \"imported-key-EXAMPLE-not-a-real-secret\",   \"name\": \"Example imported key\",   \"actor_id\": \"user_123\" } ```
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::api_keys_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let import_api_key_request = Default::default(); // ImportApiKeyRequest | Example:   {     \"raw_key\": \"imported-key-EXAMPLE-not-a-real-secret\",     \"name\": \"Example imported key\",     \"actor_id\": \"payment-processor\",     \"scopes\": [\"read\", \"write\"],     \"ttl\": \"8760h\",  // 1 year (also accepts: 31536000s)     \"metadata\": {\"source\": \"example-provider\", \"environment\": \"staging\"}   }
+    match api_keys_api::admin_import_api_key(&configuration, import_api_key_request).await {
+        Ok(response) => println!("ApiKeysApi::admin_import_api_key: {:?}", response),
+        Err(error) => eprintln!("Error calling ApiKeysApi::admin_import_api_key: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -244,6 +372,24 @@ Issue API Key
 
 Creates a new API key for a given actor. The secret is returned only once in the response and cannot be retrieved later. Keys can be scoped with specific permissions and have optional expiration.  ```http POST /v2alpha1/admin/issuedApiKeys {   \"name\": \"production-service\",   \"actor_id\": \"user_123\",   \"scopes\": [\"read\", \"write\"],   \"ttl\": \"8760h\" } ```
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::api_keys_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let issue_api_key_request = Default::default(); // IssueApiKeyRequest
+    match api_keys_api::admin_issue_api_key(&configuration, issue_api_key_request).await {
+        Ok(response) => println!("ApiKeysApi::admin_issue_api_key: {:?}", response),
+        Err(error) => eprintln!("Error calling ApiKeysApi::admin_issue_api_key: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -273,6 +419,26 @@ Name | Type | Description  | Required | Notes
 List Imported API Keys
 
 Lists all imported keys with filtering. Returns imported keys only (not issued keys). Supports pagination and AIP-160 filter expressions.  ```http GET /v2alpha1/admin/importedApiKeys?page_size=50&filter=status%3DKEY_STATUS_ACTIVE ```
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::api_keys_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let page_size = None; // i32 | Number of items per page (default: 50, max: 1000) (optional)
+    let page_token = None; // String | Cursor token for pagination (OPTIONAL) (optional)
+    let filter = None; // String | filter is an AIP-160 expression. Indexed fields (efficient at any scale):   actor_id, status. Other fields are not indexed and may be rejected. Examples:   actor_id=\"user_123\"   status=KEY_STATUS_ACTIVE   actor_id=\"user_123\" AND status=KEY_STATUS_ACTIVE (optional)
+    match api_keys_api::admin_list_imported_api_keys(&configuration, page_size, page_token, filter).await {
+        Ok(response) => println!("ApiKeysApi::admin_list_imported_api_keys: {:?}", response),
+        Err(error) => eprintln!("Error calling ApiKeysApi::admin_list_imported_api_keys: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -306,6 +472,26 @@ List Issued API Keys
 
 Lists issued API keys with optional filtering. Supports cursor-based pagination and AIP-160 filter expressions. Returns only issued (generated) API keys; use ListImportedApiKeys for imported keys.  ```http GET /v2alpha1/admin/issuedApiKeys?page_size=50&filter=actor_id%3D%22user_123%22 ```
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::api_keys_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let page_size = None; // i32 | Number of items per page (default: 50, max: 1000) (optional)
+    let page_token = None; // String | Cursor token for pagination (optional)
+    let filter = None; // String | filter is an AIP-160 expression. Indexed fields (efficient at any scale):   actor_id, status. Other fields are not indexed and may be rejected. Examples:   actor_id=\"user_123\"   status=KEY_STATUS_ACTIVE   actor_id=\"user_123\" AND status=KEY_STATUS_ACTIVE (optional)
+    match api_keys_api::admin_list_issued_api_keys(&configuration, page_size, page_token, filter).await {
+        Ok(response) => println!("ApiKeysApi::admin_list_issued_api_keys: {:?}", response),
+        Err(error) => eprintln!("Error calling ApiKeysApi::admin_list_issued_api_keys: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -338,6 +524,25 @@ Revoke Imported API Key
 
 Immediately revokes an imported API key. Once revoked, the key can no longer be used for authentication. This operation is irreversible. Revoked keys are retained for audit purposes.  ```http POST /v2alpha1/admin/importedApiKeys/9a3f051b2c7e8d4f1a6b9c0e5f2d8a3b:revoke {   \"reason\": \"REVOCATION_REASON_KEY_COMPROMISE\" } ```
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::api_keys_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let key_id = "key_id_example"; // String | SHA-512/256 hash of the imported key (REQUIRED)
+    let admin_revoke_imported_api_key_body = Default::default(); // AdminRevokeImportedApiKeyBody
+    match api_keys_api::admin_revoke_imported_api_key(&configuration, key_id, admin_revoke_imported_api_key_body).await {
+        Ok(_) => println!("ApiKeysApi::admin_revoke_imported_api_key"),
+        Err(error) => eprintln!("Error calling ApiKeysApi::admin_revoke_imported_api_key: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -368,6 +573,25 @@ Name | Type | Description  | Required | Notes
 Revoke Issued API Key
 
 Immediately revokes an issued API key. Once revoked, the key can no longer be used for authentication. This operation is irreversible. Revoked keys are retained for audit purposes.  ```http POST /v2alpha1/admin/issuedApiKeys/01HQZX9VYQKJB8XQZQXQZQXQXQ:revoke {   \"reason\": \"REVOCATION_REASON_KEY_COMPROMISE\" } ```
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::api_keys_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let key_id = "key_id_example"; // String | UUID of the issued key (REQUIRED)
+    let admin_revoke_issued_api_key_body = Default::default(); // AdminRevokeIssuedApiKeyBody
+    match api_keys_api::admin_revoke_issued_api_key(&configuration, key_id, admin_revoke_issued_api_key_body).await {
+        Ok(_) => println!("ApiKeysApi::admin_revoke_issued_api_key"),
+        Err(error) => eprintln!("Error calling ApiKeysApi::admin_revoke_issued_api_key: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -400,6 +624,25 @@ Rotate Issued API Key
 
 Generates a new secret for an issued API key. Creates a new API key with a new key_id and secret, and immediately revokes the old key. This is the recommended way to update scopes, metadata, or rotate credentials.  For zero-downtime rotation, use this workflow instead:   1. IssueApiKey with new credentials   2. Deploy new secret to all services   3. Verify new secret works everywhere   4. AdminRevokeIssuedApiKey to remove the old key  ```http POST /v2alpha1/admin/issuedApiKeys/01HQZX9VYQKJB8XQZQXQZQXQXQ:rotate {   \"scopes\": [\"read\"] } ```
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::api_keys_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let key_id = "key_id_example"; // String | key_id is the ID of the existing API key to rotate
+    let admin_rotate_issued_api_key_body = Default::default(); // AdminRotateIssuedApiKeyBody
+    match api_keys_api::admin_rotate_issued_api_key(&configuration, key_id, admin_rotate_issued_api_key_body).await {
+        Ok(response) => println!("ApiKeysApi::admin_rotate_issued_api_key: {:?}", response),
+        Err(error) => eprintln!("Error calling ApiKeysApi::admin_rotate_issued_api_key: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -430,6 +673,26 @@ Name | Type | Description  | Required | Notes
 Update Imported API Key
 
 Updates metadata, scopes, or rate limits of an imported key. Supports partial updates via the update_mask query parameter (AIP-134). Omitting update_mask is equivalent to a mask of every populated field in the body. To clear a field to its zero value, list it explicitly in update_mask and leave it unset (or empty) in the body.  ```http PATCH /v2alpha1/admin/importedApiKeys/{key_id}?update_mask=name {   \"imported_api_key\": {     \"key_id\": \"{key_id}\",     \"name\": \"New name\"   } } ```
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::api_keys_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let key_id = "key_id_example"; // String | SHA-512/256 hash of credential
+    let admin_update_imported_api_key_request = Default::default(); // AdminUpdateImportedApiKeyRequest
+    let update_mask = None; // String | The list of fields to update. See AIP-134. (optional)
+    match api_keys_api::admin_update_imported_api_key(&configuration, key_id, admin_update_imported_api_key_request, update_mask).await {
+        Ok(response) => println!("ApiKeysApi::admin_update_imported_api_key: {:?}", response),
+        Err(error) => eprintln!("Error calling ApiKeysApi::admin_update_imported_api_key: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -463,6 +726,26 @@ Update Issued API Key
 
 Updates metadata, scopes, or rate limits of an issued key without rotating the secret. Use RotateIssuedApiKey to change the secret.  Follows AIP-134: the request body is the IssuedApiKey resource itself, and the update_mask query parameter names the subset of fields to apply. Omitting update_mask is equivalent to a mask of every populated field in the body. To clear a field to its zero value, list it explicitly in update_mask and leave it unset (or empty) in the body.  ```http PATCH /v2alpha1/admin/issuedApiKeys/01HQZX9VYQKJB8XQZQXQZQXQXQ?update_mask=scopes {   \"issued_api_key\": {     \"key_id\": \"01HQZX9VYQKJB8XQZQXQZQXQXQ\",     \"scopes\": [\"read\"]   } } ```
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::api_keys_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let key_id = "key_id_example"; // String | Identifier of the API key resource.
+    let admin_update_issued_api_key_request = Default::default(); // AdminUpdateIssuedApiKeyRequest
+    let update_mask = None; // String | The list of fields to update. See AIP-134. (optional)
+    match api_keys_api::admin_update_issued_api_key(&configuration, key_id, admin_update_issued_api_key_request, update_mask).await {
+        Ok(response) => println!("ApiKeysApi::admin_update_issued_api_key: {:?}", response),
+        Err(error) => eprintln!("Error calling ApiKeysApi::admin_update_issued_api_key: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -494,6 +777,26 @@ Name | Type | Description  | Required | Notes
 Verify API Key
 
 Verifies a single API key or derived token. Validates the credential's signature, expiration, and revocation status. Works with any credential type (issued keys, imported keys, JWT, macaroon). The verification result includes decoded claims and metadata — admin access only.  Cache Control (HTTP Headers):   - Cache-Control: no-cache  - Bypasses cache read, forces fresh DB lookup   - Cache-Control: no-store  - Bypasses cache read AND write (never cached)   - Pragma: no-cache         - Same as Cache-Control: no-cache (HTTP/1.0)  ```http POST /v2alpha1/admin/apiKeys:verify {   \"credential\": \"sk_live_abc123...\" } ```
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::api_keys_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let verify_api_key_request = Default::default(); // VerifyApiKeyRequest
+    let cache_control = None; // String | Cache-directive controlling the verifier cache. `no-cache` forces a fresh database lookup (cache read is bypassed). `no-store` additionally prevents the result from being written to the cache. Any other value is ignored. (optional)
+    let pragma = None; // String | HTTP/1.0 alias for `Cache-Control: no-cache`. Behaves identically when set to `no-cache`; ignored otherwise. (optional)
+    match api_keys_api::admin_verify_api_key(&configuration, verify_api_key_request, cache_control, pragma).await {
+        Ok(response) => println!("ApiKeysApi::admin_verify_api_key: {:?}", response),
+        Err(error) => eprintln!("Error calling ApiKeysApi::admin_verify_api_key: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -527,6 +830,23 @@ Get JWKS
 
 Returns the JSON Web Key Set for token verification. Provides the public keys needed to verify JWT tokens issued by this service. Keys are loaded from configuration (file://, https://, or base64:// URIs). Follows the JWKS standard (RFC 7517).  ```http GET /v2alpha1/derivedKeys/jwks.json ```
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::api_keys_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    match api_keys_api::get_jwks(&configuration).await {
+        Ok(response) => println!("ApiKeysApi::get_jwks: {:?}", response),
+        Err(error) => eprintln!("Error calling ApiKeysApi::get_jwks: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 This endpoint does not need any parameter.
@@ -553,6 +873,24 @@ No authorization required
 Revoke API Key (self-service)
 
 Proof-of-possession variant of revocation. The `Self*` prefix on the request/response messages disambiguates from the admin variants (`AdminRevokeIssuedApiKey` / `AdminRevokeImportedApiKey`).  Allows an API key holder to revoke their own key. The caller must provide the full API key secret as proof of possession. Supports issued API keys and imported keys. JWT and macaroon tokens cannot be self-revoked (they are stateless).  The PRIVILEGE_WITHDRAWN reason is not allowed for self-revocation (admin-only).  ```http POST /v2alpha1/apiKeys:selfRevoke {   \"credential\": \"sk_live_abc123...\",   \"reason\": \"REVOCATION_REASON_KEY_COMPROMISE\" } ```
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::api_keys_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let self_revoke_api_key_request = Default::default(); // SelfRevokeApiKeyRequest | SelfRevokeApiKeyRequest allows an API key holder to revoke their own key by providing the full key secret as proof of possession.
+    match api_keys_api::revoke_api_key(&configuration, self_revoke_api_key_request).await {
+        Ok(response) => println!("ApiKeysApi::revoke_api_key: {:?}", response),
+        Err(error) => eprintln!("Error calling ApiKeysApi::revoke_api_key: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 

--- a/clients/client/rust/docs/ApiKeysApi.md
+++ b/clients/client/rust/docs/ApiKeysApi.md
@@ -839,7 +839,6 @@ use ory_client::apis::api_keys_api;
 #[tokio::main]
 async fn main() {
     let mut configuration = Configuration::new();
-    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
     match api_keys_api::get_jwks(&configuration).await {
         Ok(response) => println!("ApiKeysApi::get_jwks: {:?}", response),
         Err(error) => eprintln!("Error calling ApiKeysApi::get_jwks: {:?}", error),
@@ -883,7 +882,6 @@ use ory_client::apis::api_keys_api;
 #[tokio::main]
 async fn main() {
     let mut configuration = Configuration::new();
-    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
     let self_revoke_api_key_request = Default::default(); // SelfRevokeApiKeyRequest | SelfRevokeApiKeyRequest allows an API key holder to revoke their own key by providing the full key secret as proof of possession.
     match api_keys_api::revoke_api_key(&configuration, self_revoke_api_key_request).await {
         Ok(response) => println!("ApiKeysApi::revoke_api_key: {:?}", response),

--- a/clients/client/rust/docs/CourierApi.md
+++ b/clients/client/rust/docs/CourierApi.md
@@ -16,6 +16,24 @@ Get a Message
 
 Gets a specific messages by the given ID.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::courier_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let id = "id_example"; // String | MessageID is the ID of the message.
+    match courier_api::get_courier_message(&configuration, id).await {
+        Ok(response) => println!("CourierApi::get_courier_message: {:?}", response),
+        Err(error) => eprintln!("Error calling CourierApi::get_courier_message: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -45,6 +63,27 @@ Name | Type | Description  | Required | Notes
 List Messages
 
 Lists all messages by given status and recipient.
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::courier_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let page_size = None; // i64 | Items per Page  This is the number of items per page to return. For details on pagination please head over to the [pagination documentation](https://www.ory.com/docs/ecosystem/api-design#pagination). (optional)
+    let page_token = None; // String | Next Page Token  The next page token. For details on pagination please head over to the [pagination documentation](https://www.ory.com/docs/ecosystem/api-design#pagination). (optional)
+    let status = None; // CourierMessageStatus | Status filters out messages based on status. If no value is provided, it doesn't take effect on filter. (optional)
+    let recipient = None; // String | Recipient filters out messages based on recipient. If no value is provided, it doesn't take effect on filter. (optional)
+    match courier_api::list_courier_messages(&configuration, page_size, page_token, status, recipient).await {
+        Ok(response) => println!("CourierApi::list_courier_messages: {:?}", response),
+        Err(error) => eprintln!("Error calling CourierApi::list_courier_messages: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 

--- a/clients/client/rust/docs/ElementsApi.md
+++ b/clients/client/rust/docs/ElementsApi.md
@@ -15,6 +15,23 @@ Get Ory Elements configuration
 
 Returns a subset of the project's configuration for the given host. The response only contains non-sensitive data that is used to customize the behavior of Ory Elements.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::elements_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    match elements_api::get_configuration(&configuration).await {
+        Ok(response) => println!("ElementsApi::get_configuration: {:?}", response),
+        Err(error) => eprintln!("Error calling ElementsApi::get_configuration: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 This endpoint does not need any parameter.

--- a/clients/client/rust/docs/ElementsApi.md
+++ b/clients/client/rust/docs/ElementsApi.md
@@ -24,7 +24,6 @@ use ory_client::apis::elements_api;
 #[tokio::main]
 async fn main() {
     let mut configuration = Configuration::new();
-    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
     match elements_api::get_configuration(&configuration).await {
         Ok(response) => println!("ElementsApi::get_configuration: {:?}", response),
         Err(error) => eprintln!("Error calling ElementsApi::get_configuration: {:?}", error),

--- a/clients/client/rust/docs/EventsApi.md
+++ b/clients/client/rust/docs/EventsApi.md
@@ -16,6 +16,25 @@ Method | HTTP request | Description
 > models::EventStream create_event_stream(project_id, create_event_stream_body)
 Create an event stream for your project.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::events_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let project_id = "project_id_example"; // String | Project ID  The project's ID.
+    let create_event_stream_body = Default::default(); // CreateEventStreamBody
+    match events_api::create_event_stream(&configuration, project_id, create_event_stream_body).await {
+        Ok(response) => println!("EventsApi::create_event_stream: {:?}", response),
+        Err(error) => eprintln!("Error calling EventsApi::create_event_stream: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -47,6 +66,25 @@ Remove an event stream from a project
 
 Remove an event stream from a project.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::events_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let project_id = "project_id_example"; // String | Project ID  The project's ID.
+    let event_stream_id = "event_stream_id_example"; // String | Event Stream ID  The ID of the event stream to be deleted, as returned when created.
+    match events_api::delete_event_stream(&configuration, project_id, event_stream_id).await {
+        Ok(_) => println!("EventsApi::delete_event_stream"),
+        Err(error) => eprintln!("Error calling EventsApi::delete_event_stream: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -76,6 +114,24 @@ Name | Type | Description  | Required | Notes
 > models::ListEventStreams list_event_streams(project_id)
 List all event streams for the project. This endpoint is not paginated.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::events_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let project_id = "project_id_example"; // String | Project ID  The project's ID.
+    match events_api::list_event_streams(&configuration, project_id).await {
+        Ok(response) => println!("EventsApi::list_event_streams: {:?}", response),
+        Err(error) => eprintln!("Error calling EventsApi::list_event_streams: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -103,6 +159,26 @@ Name | Type | Description  | Required | Notes
 
 > models::EventStream set_event_stream(project_id, event_stream_id, set_event_stream_body)
 Update an event stream for a project.
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::events_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let project_id = "project_id_example"; // String | Project ID  The project's ID.
+    let event_stream_id = "event_stream_id_example"; // String | Event Stream ID  The event stream's ID.
+    let set_event_stream_body = Some(Default::default()); // SetEventStreamBody (optional)
+    match events_api::set_event_stream(&configuration, project_id, event_stream_id, set_event_stream_body).await {
+        Ok(response) => println!("EventsApi::set_event_stream: {:?}", response),
+        Err(error) => eprintln!("Error calling EventsApi::set_event_stream: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 

--- a/clients/client/rust/docs/FrontendApi.md
+++ b/clients/client/rust/docs/FrontendApi.md
@@ -48,6 +48,31 @@ Create Login Flow for Browsers
 
 This endpoint initializes a browser-based user login flow. This endpoint will set the appropriate cookies and anti-CSRF measures required for browser-based flows.  If this endpoint is opened as a link in the browser, it will be redirected to `selfservice.flows.login.ui_url` with the flow ID set as the query parameter `?flow=`. If a valid user session exists already, the browser will be redirected to `urls.default_redirect_url` unless the query parameter `?refresh=true` was set.  If this endpoint is called via an AJAX request, the response contains the flow without a redirect. In the case of an error, the `error.id` of the JSON response body can be one of:  `session_already_available`: The user is already signed in. `session_aal1_required`: Multi-factor auth (e.g. 2fa) was requested but the user has no session yet. `security_csrf_violation`: Unable to fetch the flow because a CSRF violation occurred. `security_identity_mismatch`: The requested `?return_to` address is not allowed to be used. Adjust this in the configuration!  The optional query parameter login_challenge is set when using Kratos with Hydra in an OAuth2 flow. See the oauth2_provider.url configuration option.  This endpoint is NOT INTENDED for clients that do not have a browser (Chrome, Firefox, ...) as cookies are needed.  More information can be found at [Ory Kratos User Login](https://www.ory.com/docs/kratos/self-service/flows/user-login) and [User Registration Documentation](https://www.ory.com/docs/kratos/self-service/flows/user-registration).
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::frontend_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let refresh = None; // bool | Refresh a login session  If set to true, this will refresh an existing login session by asking the user to sign in again. This will reset the authenticated_at time of the session. (optional)
+    let aal = None; // String | Request a Specific AuthenticationMethod Assurance Level  Use this parameter to upgrade an existing session's authenticator assurance level (AAL). This allows you to ask for multi-factor authentication. When an identity sign in using e.g. username+password, the AAL is 1. If you wish to \"upgrade\" the session's security by asking the user to perform TOTP / WebAuth/ ... you would set this to \"aal2\". (optional)
+    let return_to = None; // String | The URL to return the browser to after the flow was completed. (optional)
+    let cookie = None; // String | HTTP Cookies  When using the SDK in a browser app, on the server side you must include the HTTP Cookie Header sent by the client to your server here. This ensures that CSRF and session cookies are respected. (optional)
+    let login_challenge = None; // String | An optional Hydra login challenge. If present, Kratos will cooperate with Ory Hydra to act as an OAuth2 identity provider.  The value for this parameter comes from `login_challenge` URL Query parameter sent to your application (e.g. `/login?login_challenge=abcde`). (optional)
+    let organization = None; // String | An optional organization ID that should be used for logging this user in. This parameter is only effective in the Ory Network. (optional)
+    let via = None; // String | Via should contain the identity's credential the code should be sent to. Only relevant in aal2 flows.  DEPRECATED: This field is deprecated. Please remove it from your requests. The user will now see a choice of MFA credentials to choose from to perform the second factor instead. (optional)
+    let identity_schema = None; // String | An optional identity schema to use for the login flow. (optional)
+    match frontend_api::create_browser_login_flow(&configuration, refresh, aal, return_to, cookie, login_challenge, organization, via, identity_schema).await {
+        Ok(response) => println!("FrontendApi::create_browser_login_flow: {:?}", response),
+        Err(error) => eprintln!("Error calling FrontendApi::create_browser_login_flow: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -85,6 +110,25 @@ Create a Logout URL for Browsers
 
 This endpoint initializes a browser-based user logout flow and a URL which can be used to log out the user.  This endpoint is NOT INTENDED for API clients and only works with browsers (Chrome, Firefox, ...). For API clients you can call the `/self-service/logout/api` URL directly with the Ory Session Token.  The URL is only valid for the currently signed in user. If no user is signed in, this endpoint returns a 401 error.  When calling this endpoint from a backend, please ensure to properly forward the HTTP cookies.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::frontend_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let cookie = None; // String | HTTP Cookies  If you call this endpoint from a backend, please include the original Cookie header in the request. (optional)
+    let return_to = None; // String | Return to URL  The URL to which the browser should be redirected to after the logout has been performed. (optional)
+    match frontend_api::create_browser_logout_flow(&configuration, cookie, return_to).await {
+        Ok(response) => println!("FrontendApi::create_browser_logout_flow: {:?}", response),
+        Err(error) => eprintln!("Error calling FrontendApi::create_browser_logout_flow: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -116,6 +160,25 @@ Create Recovery Flow for Browsers
 
 This endpoint initializes a browser-based account recovery flow. Once initialized, the browser will be redirected to `selfservice.flows.recovery.ui_url` with the flow ID set as the query parameter `?flow=`. If a valid user session exists, the browser is returned to the configured return URL.  If this endpoint is called via an AJAX request, the response contains the recovery flow without any redirects or a 400 bad request error if the user is already authenticated.  This endpoint is NOT INTENDED for clients that do not have a browser (Chrome, Firefox, ...) as cookies are needed.  More information can be found at [Ory Kratos Account Recovery Documentation](../self-service/flows/account-recovery).
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::frontend_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let return_to = None; // String | The URL to return the browser to after the flow was completed. (optional)
+    let skip_settings = None; // String | Skip redirection to the settings UI after the recovery flow was completed. Instead, the user will be redirected to the URL specified in `return_to` query parameter or the default return URL if `return_to` is not set. (optional)
+    match frontend_api::create_browser_recovery_flow(&configuration, return_to, skip_settings).await {
+        Ok(response) => println!("FrontendApi::create_browser_recovery_flow: {:?}", response),
+        Err(error) => eprintln!("Error calling FrontendApi::create_browser_recovery_flow: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -146,6 +209,28 @@ No authorization required
 Create Registration Flow for Browsers
 
 This endpoint initializes a browser-based user registration flow. This endpoint will set the appropriate cookies and anti-CSRF measures required for browser-based flows.  If this endpoint is opened as a link in the browser, it will be redirected to `selfservice.flows.registration.ui_url` with the flow ID set as the query parameter `?flow=`. If a valid user session exists already, the browser will be redirected to `urls.default_redirect_url`.  If this endpoint is called via an AJAX request, the response contains the flow without a redirect. In the case of an error, the `error.id` of the JSON response body can be one of:  `session_already_available`: The user is already signed in. `security_csrf_violation`: Unable to fetch the flow because a CSRF violation occurred. `security_identity_mismatch`: The requested `?return_to` address is not allowed to be used. Adjust this in the configuration!  If this endpoint is called via an AJAX request, the response contains the registration flow without a redirect.  This endpoint is NOT INTENDED for clients that do not have a browser (Chrome, Firefox, ...) as cookies are needed.  More information can be found at [Ory Kratos User Login](https://www.ory.com/docs/kratos/self-service/flows/user-login) and [User Registration Documentation](https://www.ory.com/docs/kratos/self-service/flows/user-registration).
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::frontend_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let return_to = None; // String | The URL to return the browser to after the flow was completed. (optional)
+    let login_challenge = None; // String | Ory OAuth 2.0 Login Challenge.  If set will cooperate with Ory OAuth2 and OpenID to act as an OAuth2 server / OpenID Provider.  The value for this parameter comes from `login_challenge` URL Query parameter sent to your application (e.g. `/registration?login_challenge=abcde`).  This feature is compatible with Ory Hydra when not running on the Ory Network. (optional)
+    let after_verification_return_to = None; // String | The URL to return the browser to after the verification flow was completed.  After the registration flow is completed, the user will be sent a verification email. Upon completing the verification flow, this URL will be used to override the default `selfservice.flows.verification.after.default_redirect_to` value. (optional)
+    let organization = None; // String | An optional organization ID that should be used to register this user. This parameter is only effective in the Ory Network. (optional)
+    let identity_schema = None; // String | An optional identity schema to use for the registration flow. (optional)
+    match frontend_api::create_browser_registration_flow(&configuration, return_to, login_challenge, after_verification_return_to, organization, identity_schema).await {
+        Ok(response) => println!("FrontendApi::create_browser_registration_flow: {:?}", response),
+        Err(error) => eprintln!("Error calling FrontendApi::create_browser_registration_flow: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -181,6 +266,26 @@ Create Settings Flow for Browsers
 
 This endpoint initializes a browser-based user settings flow. Once initialized, the browser will be redirected to `selfservice.flows.settings.ui_url` with the flow ID set as the query parameter `?flow=`. If no valid Ory Kratos Session Cookie is included in the request, a login flow will be initialized.  If this endpoint is opened as a link in the browser, it will be redirected to `selfservice.flows.settings.ui_url` with the flow ID set as the query parameter `?flow=`. If no valid user session was set, the browser will be redirected to the login endpoint.  If this endpoint is called via an AJAX request, the response contains the settings flow without any redirects or a 401 forbidden error if no valid session was set.  Depending on your configuration this endpoint might return a 403 error if the session has a lower Authenticator Assurance Level (AAL) than is possible for the identity. This can happen if the identity has password + webauthn credentials (which would result in AAL2) but the session has only AAL1. If this error occurs, ask the user to sign in with the second factor (happens automatically for server-side browser flows) or change the configuration.  If this endpoint is called via an AJAX request, the response contains the flow without a redirect. In the case of an error, the `error.id` of the JSON response body can be one of:  `security_csrf_violation`: Unable to fetch the flow because a CSRF violation occurred. `session_inactive`: No Ory Session was found - sign in a user first. `security_identity_mismatch`: The requested `?return_to` address is not allowed to be used. Adjust this in the configuration!  This endpoint is NOT INTENDED for clients that do not have a browser (Chrome, Firefox, ...) as cookies are needed.  More information can be found at [Ory Kratos User Settings & Profile Management Documentation](../self-service/flows/user-settings).
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::frontend_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let return_to = None; // String | The URL to return the browser to after the flow was completed. (optional)
+    let cookie = None; // String | HTTP Cookies  When using the SDK in a browser app, on the server side you must include the HTTP Cookie Header sent by the client to your server here. This ensures that CSRF and session cookies are respected. (optional)
+    let organization = None; // String | An optional organization ID that scopes the settings flow to providers of that organization. This parameter is only effective in the Ory Network. (optional)
+    match frontend_api::create_browser_settings_flow(&configuration, return_to, cookie, organization).await {
+        Ok(response) => println!("FrontendApi::create_browser_settings_flow: {:?}", response),
+        Err(error) => eprintln!("Error calling FrontendApi::create_browser_settings_flow: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -213,6 +318,24 @@ Create Verification Flow for Browser Clients
 
 This endpoint initializes a browser-based account verification flow. Once initialized, the browser will be redirected to `selfservice.flows.verification.ui_url` with the flow ID set as the query parameter `?flow=`.  If this endpoint is called via an AJAX request, the response contains the recovery flow without any redirects.  This endpoint is NOT INTENDED for API clients and only works with browsers (Chrome, Firefox, ...).  More information can be found at [Ory Kratos Email and Phone Verification Documentation](https://www.ory.com/docs/kratos/self-service/flows/verify-email-account-activation).
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::frontend_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let return_to = None; // String | The URL to return the browser to after the flow was completed. (optional)
+    match frontend_api::create_browser_verification_flow(&configuration, return_to).await {
+        Ok(response) => println!("FrontendApi::create_browser_verification_flow: {:?}", response),
+        Err(error) => eprintln!("Error calling FrontendApi::create_browser_verification_flow: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -243,6 +366,23 @@ Get FedCM Parameters
 
 This endpoint returns a list of all available FedCM providers. It is only supported on the Ory Network.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::frontend_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    match frontend_api::create_fedcm_flow(&configuration).await {
+        Ok(response) => println!("FrontendApi::create_fedcm_flow: {:?}", response),
+        Err(error) => eprintln!("Error calling FrontendApi::create_fedcm_flow: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 This endpoint does not need any parameter.
@@ -269,6 +409,31 @@ No authorization required
 Create Login Flow for Native Apps
 
 This endpoint initiates a login flow for native apps that do not use a browser, such as mobile devices, smart TVs, and so on.  If a valid provided session cookie or session token is provided, a 400 Bad Request error will be returned unless the URL query parameter `?refresh=true` is set.  To fetch an existing login flow call `/self-service/login/flows?flow=<flow_id>`.  You MUST NOT use this endpoint in client-side (Single Page Apps, ReactJS, AngularJS) nor server-side (Java Server Pages, NodeJS, PHP, Golang, ...) browser applications. Using this endpoint in these applications will make you vulnerable to a variety of CSRF attacks, including CSRF login attacks.  In the case of an error, the `error.id` of the JSON response body can be one of:  `session_already_available`: The user is already signed in. `session_aal1_required`: Multi-factor auth (e.g. 2fa) was requested but the user has no session yet. `security_csrf_violation`: Unable to fetch the flow because a CSRF violation occurred.  This endpoint MUST ONLY be used in scenarios such as native mobile apps (React Native, Objective C, Swift, Java, ...).  More information can be found at [Ory Kratos User Login](https://www.ory.com/docs/kratos/self-service/flows/user-login) and [User Registration Documentation](https://www.ory.com/docs/kratos/self-service/flows/user-registration).
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::frontend_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let refresh = None; // bool | Refresh a login session  If set to true, this will refresh an existing login session by asking the user to sign in again. This will reset the authenticated_at time of the session. (optional)
+    let aal = None; // String | Request a Specific AuthenticationMethod Assurance Level  Use this parameter to upgrade an existing session's authenticator assurance level (AAL). This allows you to ask for multi-factor authentication. When an identity sign in using e.g. username+password, the AAL is 1. If you wish to \"upgrade\" the session's security by asking the user to perform TOTP / WebAuth/ ... you would set this to \"aal2\". (optional)
+    let x_session_token = None; // String | The Session Token of the Identity performing the settings flow. (optional)
+    let return_session_token_exchange_code = None; // bool | EnableSessionTokenExchangeCode requests the login flow to include a code that can be used to retrieve the session token after the login flow has been completed. (optional)
+    let return_to = None; // String | The URL to return the browser to after the flow was completed. (optional)
+    let organization = None; // String | An optional organization ID that should be used for logging this user in. This parameter is only effective in the Ory Network. (optional)
+    let via = None; // String | Via should contain the identity's credential the code should be sent to. Only relevant in aal2 flows.  DEPRECATED: This field is deprecated. Please remove it from your requests. The user will now see a choice of MFA credentials to choose from to perform the second factor instead. (optional)
+    let identity_schema = None; // String | An optional identity schema to use for the login flow. (optional)
+    match frontend_api::create_native_login_flow(&configuration, refresh, aal, x_session_token, return_session_token_exchange_code, return_to, organization, via, identity_schema).await {
+        Ok(response) => println!("FrontendApi::create_native_login_flow: {:?}", response),
+        Err(error) => eprintln!("Error calling FrontendApi::create_native_login_flow: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -307,6 +472,23 @@ Create Recovery Flow for Native Apps
 
 This endpoint initiates a recovery flow for API clients such as mobile devices, smart TVs, and so on.  If a valid provided session cookie or session token is provided, a 400 Bad Request error.  On an existing recovery flow, use the `getRecoveryFlow` API endpoint.  You MUST NOT use this endpoint in client-side (Single Page Apps, ReactJS, AngularJS) nor server-side (Java Server Pages, NodeJS, PHP, Golang, ...) browser applications. Using this endpoint in these applications will make you vulnerable to a variety of CSRF attacks.  This endpoint MUST ONLY be used in scenarios such as native mobile apps (React Native, Objective C, Swift, Java, ...).  More information can be found at [Ory Kratos Account Recovery Documentation](../self-service/flows/account-recovery).
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::frontend_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    match frontend_api::create_native_recovery_flow(&configuration).await {
+        Ok(response) => println!("FrontendApi::create_native_recovery_flow: {:?}", response),
+        Err(error) => eprintln!("Error calling FrontendApi::create_native_recovery_flow: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 This endpoint does not need any parameter.
@@ -333,6 +515,27 @@ No authorization required
 Create Registration Flow for Native Apps
 
 This endpoint initiates a registration flow for API clients such as mobile devices, smart TVs, and so on.  If a valid provided session cookie or session token is provided, a 400 Bad Request error will be returned unless the URL query parameter `?refresh=true` is set.  To fetch an existing registration flow call `/self-service/registration/flows?flow=<flow_id>`.  You MUST NOT use this endpoint in client-side (Single Page Apps, ReactJS, AngularJS) nor server-side (Java Server Pages, NodeJS, PHP, Golang, ...) browser applications. Using this endpoint in these applications will make you vulnerable to a variety of CSRF attacks.  In the case of an error, the `error.id` of the JSON response body can be one of:  `session_already_available`: The user is already signed in. `security_csrf_violation`: Unable to fetch the flow because a CSRF violation occurred.  This endpoint MUST ONLY be used in scenarios such as native mobile apps (React Native, Objective C, Swift, Java, ...).  More information can be found at [Ory Kratos User Login](https://www.ory.com/docs/kratos/self-service/flows/user-login) and [User Registration Documentation](https://www.ory.com/docs/kratos/self-service/flows/user-registration).
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::frontend_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let return_session_token_exchange_code = None; // bool | EnableSessionTokenExchangeCode requests the login flow to include a code that can be used to retrieve the session token after the login flow has been completed. (optional)
+    let return_to = None; // String | The URL to return the browser to after the flow was completed. (optional)
+    let organization = None; // String | An optional organization ID that should be used to register this user. This parameter is only effective in the Ory Network. (optional)
+    let identity_schema = None; // String | An optional identity schema to use for the registration flow. (optional)
+    match frontend_api::create_native_registration_flow(&configuration, return_session_token_exchange_code, return_to, organization, identity_schema).await {
+        Ok(response) => println!("FrontendApi::create_native_registration_flow: {:?}", response),
+        Err(error) => eprintln!("Error calling FrontendApi::create_native_registration_flow: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -367,6 +570,25 @@ Create Settings Flow for Native Apps
 
 This endpoint initiates a settings flow for API clients such as mobile devices, smart TVs, and so on. You must provide a valid Ory Kratos Session Token for this endpoint to respond with HTTP 200 OK.  To fetch an existing settings flow call `/self-service/settings/flows?flow=<flow_id>`.  You MUST NOT use this endpoint in client-side (Single Page Apps, ReactJS, AngularJS) nor server-side (Java Server Pages, NodeJS, PHP, Golang, ...) browser applications. Using this endpoint in these applications will make you vulnerable to a variety of CSRF attacks.  Depending on your configuration this endpoint might return a 403 error if the session has a lower Authenticator Assurance Level (AAL) than is possible for the identity. This can happen if the identity has password + webauthn credentials (which would result in AAL2) but the session has only AAL1. If this error occurs, ask the user to sign in with the second factor or change the configuration.  In the case of an error, the `error.id` of the JSON response body can be one of:  `security_csrf_violation`: Unable to fetch the flow because a CSRF violation occurred. `session_inactive`: No Ory Session was found - sign in a user first.  This endpoint MUST ONLY be used in scenarios such as native mobile apps (React Native, Objective C, Swift, Java, ...).  More information can be found at [Ory Kratos User Settings & Profile Management Documentation](../self-service/flows/user-settings).
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::frontend_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let x_session_token = None; // String | The Session Token of the Identity performing the settings flow. (optional)
+    let organization = None; // String | An optional organization ID that scopes the settings flow to providers of that organization. This parameter is only effective in the Ory Network. (optional)
+    match frontend_api::create_native_settings_flow(&configuration, x_session_token, organization).await {
+        Ok(response) => println!("FrontendApi::create_native_settings_flow: {:?}", response),
+        Err(error) => eprintln!("Error calling FrontendApi::create_native_settings_flow: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -398,6 +620,24 @@ Create Verification Flow for Native Apps
 
 This endpoint initiates a verification flow for API clients such as mobile devices, smart TVs, and so on.  To fetch an existing verification flow call `/self-service/verification/flows?flow=<flow_id>`.  You MUST NOT use this endpoint in client-side (Single Page Apps, ReactJS, AngularJS) nor server-side (Java Server Pages, NodeJS, PHP, Golang, ...) browser applications. Using this endpoint in these applications will make you vulnerable to a variety of CSRF attacks.  This endpoint MUST ONLY be used in scenarios such as native mobile apps (React Native, Objective C, Swift, Java, ...).  More information can be found at [Ory Email and Phone Verification Documentation](https://www.ory.com/docs/kratos/self-service/flows/verify-email-account-activation).
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::frontend_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let return_to = None; // String | A URL contained in the return_to key of the verification flow. This piece of data has no effect on the actual logic of the flow and is purely informational. (optional)
+    match frontend_api::create_native_verification_flow(&configuration, return_to).await {
+        Ok(response) => println!("FrontendApi::create_native_verification_flow: {:?}", response),
+        Err(error) => eprintln!("Error calling FrontendApi::create_native_verification_flow: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -427,6 +667,25 @@ No authorization required
 Delete a test OIDC login flow
 
 Deletes a dry-run OIDC test login flow. A flow whose debug payload has been captured requires the HMAC cookie set by the OIDC callback; a flow still in the initial choose-method state is deletable with just the flow ID (it carries no PII, and the admin may want to abandon it).
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::frontend_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let id = "id_example"; // String | ID of the test login flow to delete.
+    let cookie = None; // String | HTTP Cookies. A captured test flow requires the ory_kratos_test_flow cookie set by the OIDC callback; a flow still in the initial choose-method state does not. (optional)
+    match frontend_api::delete_test_login_flow(&configuration, id, cookie).await {
+        Ok(_) => println!("FrontendApi::delete_test_login_flow"),
+        Err(error) => eprintln!("Error calling FrontendApi::delete_test_login_flow: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -459,6 +718,25 @@ Disable my other sessions
 
 Calling this endpoint invalidates all except the current session that belong to the logged-in user. Session data are not deleted.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::frontend_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let x_session_token = None; // String | Set the Session Token when calling from non-browser clients. A session token has a format of `MP2YWEMeM8MxjkGKpH4dqOQ4Q4DlSPaj`. (optional)
+    let cookie = None; // String | Set the Cookie Header. This is especially useful when calling this endpoint from a server-side application. In that scenario you must include the HTTP Cookie Header which originally was included in the request to your server. An example of a session in the HTTP Cookie Header is: `ory_kratos_session=a19iOVAbdzdgl70Rq1QZmrKmcjDtdsviCTZx7m9a9yHIUS8Wa9T7hvqyGTsLHi6Qifn2WUfpAKx9DWp0SJGleIn9vh2YF4A16id93kXFTgIgmwIOvbVAScyrx7yVl6bPZnCx27ec4WQDtaTewC1CpgudeDV2jQQnSaCP6ny3xa8qLH-QUgYqdQuoA_LF1phxgRCUfIrCLQOkolX5nv3ze_f==`.  It is ok if more than one cookie are included here as all other cookies will be ignored. (optional)
+    match frontend_api::disable_my_other_sessions(&configuration, x_session_token, cookie).await {
+        Ok(response) => println!("FrontendApi::disable_my_other_sessions: {:?}", response),
+        Err(error) => eprintln!("Error calling FrontendApi::disable_my_other_sessions: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -490,6 +768,26 @@ Disable one of my sessions
 
 Calling this endpoint invalidates the specified session. The current session cannot be revoked. Session data are not deleted.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::frontend_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let id = "id_example"; // String | ID is the session's ID.
+    let x_session_token = None; // String | Set the Session Token when calling from non-browser clients. A session token has a format of `MP2YWEMeM8MxjkGKpH4dqOQ4Q4DlSPaj`. (optional)
+    let cookie = None; // String | Set the Cookie Header. This is especially useful when calling this endpoint from a server-side application. In that scenario you must include the HTTP Cookie Header which originally was included in the request to your server. An example of a session in the HTTP Cookie Header is: `ory_kratos_session=a19iOVAbdzdgl70Rq1QZmrKmcjDtdsviCTZx7m9a9yHIUS8Wa9T7hvqyGTsLHi6Qifn2WUfpAKx9DWp0SJGleIn9vh2YF4A16id93kXFTgIgmwIOvbVAScyrx7yVl6bPZnCx27ec4WQDtaTewC1CpgudeDV2jQQnSaCP6ny3xa8qLH-QUgYqdQuoA_LF1phxgRCUfIrCLQOkolX5nv3ze_f==`.  It is ok if more than one cookie are included here as all other cookies will be ignored. (optional)
+    match frontend_api::disable_my_session(&configuration, id, x_session_token, cookie).await {
+        Ok(_) => println!("FrontendApi::disable_my_session"),
+        Err(error) => eprintln!("Error calling FrontendApi::disable_my_session: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -519,6 +817,25 @@ No authorization required
 
 > models::SuccessfulNativeLogin exchange_session_token(init_code, return_to_code)
 Exchange Session Token
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::frontend_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let init_code = "init_code_example"; // String | The part of the code return when initializing the flow.
+    let return_to_code = "return_to_code_example"; // String | The part of the code returned by the return_to URL.
+    match frontend_api::exchange_session_token(&configuration, init_code, return_to_code).await {
+        Ok(response) => println!("FrontendApi::exchange_session_token: {:?}", response),
+        Err(error) => eprintln!("Error calling FrontendApi::exchange_session_token: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -551,6 +868,24 @@ Get User-Flow Errors
 
 This endpoint returns the error associated with a user-facing self service errors.  This endpoint supports stub values to help you implement the error UI:  `?id=stub:500` - returns a stub 500 (Internal Server Error) error.  More information can be found at [Ory Kratos User User Facing Error Documentation](https://www.ory.com/docs/kratos/self-service/flows/user-facing-errors).
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::frontend_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let id = "id_example"; // String | Error is the error's ID
+    match frontend_api::get_flow_error(&configuration, id).await {
+        Ok(response) => println!("FrontendApi::get_flow_error: {:?}", response),
+        Err(error) => eprintln!("Error calling FrontendApi::get_flow_error: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -580,6 +915,25 @@ No authorization required
 Get Login Flow
 
 This endpoint returns a login flow's context with, for example, error details and other information.  Browser flows expect the anti-CSRF cookie to be included in the request's HTTP Cookie Header. For AJAX requests you must ensure that cookies are included in the request or requests will fail.  If you use the browser-flow for server-side apps, the services need to run on a common top-level-domain and you need to forward the incoming HTTP Cookie header to this endpoint:  ```js pseudo-code example router.get('/login', async function (req, res) { const flow = await client.getLoginFlow(req.header('cookie'), req.query['flow'])  res.render('login', flow) }) ```  This request may fail due to several reasons. The `error.id` can be one of:  `session_already_available`: The user is already signed in. `self_service_flow_expired`: The flow is expired and you should request a new one.  More information can be found at [Ory Kratos User Login](https://www.ory.com/docs/kratos/self-service/flows/user-login) and [User Registration Documentation](https://www.ory.com/docs/kratos/self-service/flows/user-registration).
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::frontend_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let id = "id_example"; // String | The Login Flow ID  The value for this parameter comes from `flow` URL Query parameter sent to your application (e.g. `/login?flow=abcde`).
+    let cookie = None; // String | HTTP Cookies  When using the SDK in a browser app, on the server side you must include the HTTP Cookie Header sent by the client to your server here. This ensures that CSRF and session cookies are respected. (optional)
+    match frontend_api::get_login_flow(&configuration, id, cookie).await {
+        Ok(response) => println!("FrontendApi::get_login_flow: {:?}", response),
+        Err(error) => eprintln!("Error calling FrontendApi::get_login_flow: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -612,6 +966,25 @@ Get Recovery Flow
 
 This endpoint returns a recovery flow's context with, for example, error details and other information.  Browser flows expect the anti-CSRF cookie to be included in the request's HTTP Cookie Header. For AJAX requests you must ensure that cookies are included in the request or requests will fail.  If you use the browser-flow for server-side apps, the services need to run on a common top-level-domain and you need to forward the incoming HTTP Cookie header to this endpoint:  ```js pseudo-code example router.get('/recovery', async function (req, res) { const flow = await client.getRecoveryFlow(req.header('Cookie'), req.query['flow'])  res.render('recovery', flow) }) ```  More information can be found at [Ory Kratos Account Recovery Documentation](../self-service/flows/account-recovery).
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::frontend_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let id = "id_example"; // String | The Flow ID  The value for this parameter comes from `request` URL Query parameter sent to your application (e.g. `/recovery?flow=abcde`).
+    let cookie = None; // String | HTTP Cookies  When using the SDK in a browser app, on the server side you must include the HTTP Cookie Header sent by the client to your server here. This ensures that CSRF and session cookies are respected. (optional)
+    match frontend_api::get_recovery_flow(&configuration, id, cookie).await {
+        Ok(response) => println!("FrontendApi::get_recovery_flow: {:?}", response),
+        Err(error) => eprintln!("Error calling FrontendApi::get_recovery_flow: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -643,6 +1016,25 @@ Get Registration Flow
 
 This endpoint returns a registration flow's context with, for example, error details and other information.  Browser flows expect the anti-CSRF cookie to be included in the request's HTTP Cookie Header. For AJAX requests you must ensure that cookies are included in the request or requests will fail.  If you use the browser-flow for server-side apps, the services need to run on a common top-level-domain and you need to forward the incoming HTTP Cookie header to this endpoint:  ```js pseudo-code example router.get('/registration', async function (req, res) { const flow = await client.getRegistrationFlow(req.header('cookie'), req.query['flow'])  res.render('registration', flow) }) ```  This request may fail due to several reasons. The `error.id` can be one of:  `session_already_available`: The user is already signed in. `self_service_flow_expired`: The flow is expired and you should request a new one.  More information can be found at [Ory Kratos User Login](https://www.ory.com/docs/kratos/self-service/flows/user-login) and [User Registration Documentation](https://www.ory.com/docs/kratos/self-service/flows/user-registration).
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::frontend_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let id = "id_example"; // String | The Registration Flow ID  The value for this parameter comes from `flow` URL Query parameter sent to your application (e.g. `/registration?flow=abcde`).
+    let cookie = None; // String | HTTP Cookies  When using the SDK in a browser app, on the server side you must include the HTTP Cookie Header sent by the client to your server here. This ensures that CSRF and session cookies are respected. (optional)
+    match frontend_api::get_registration_flow(&configuration, id, cookie).await {
+        Ok(response) => println!("FrontendApi::get_registration_flow: {:?}", response),
+        Err(error) => eprintln!("Error calling FrontendApi::get_registration_flow: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -673,6 +1065,26 @@ No authorization required
 Get Settings Flow
 
 When accessing this endpoint through Ory Kratos' Public API you must ensure that either the Ory Kratos Session Cookie or the Ory Kratos Session Token are set.  Depending on your configuration this endpoint might return a 403 error if the session has a lower Authenticator Assurance Level (AAL) than is possible for the identity. This can happen if the identity has password + webauthn credentials (which would result in AAL2) but the session has only AAL1. If this error occurs, ask the user to sign in with the second factor or change the configuration.  You can access this endpoint without credentials when using Ory Kratos' Admin API.  If this endpoint is called via an AJAX request, the response contains the flow without a redirect. In the case of an error, the `error.id` of the JSON response body can be one of:  `security_csrf_violation`: Unable to fetch the flow because a CSRF violation occurred. `session_inactive`: No Ory Session was found - sign in a user first. `security_identity_mismatch`: The flow was interrupted with `session_refresh_required` but apparently some other identity logged in instead.  More information can be found at [Ory Kratos User Settings & Profile Management Documentation](../self-service/flows/user-settings).
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::frontend_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let id = "id_example"; // String | ID is the Settings Flow ID  The value for this parameter comes from `flow` URL Query parameter sent to your application (e.g. `/settings?flow=abcde`).
+    let x_session_token = None; // String | The Session Token  When using the SDK in an app without a browser, please include the session token here. (optional)
+    let cookie = None; // String | HTTP Cookies  When using the SDK in a browser app, on the server side you must include the HTTP Cookie Header sent by the client to your server here. This ensures that CSRF and session cookies are respected. (optional)
+    match frontend_api::get_settings_flow(&configuration, id, x_session_token, cookie).await {
+        Ok(response) => println!("FrontendApi::get_settings_flow: {:?}", response),
+        Err(error) => eprintln!("Error calling FrontendApi::get_settings_flow: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -706,6 +1118,25 @@ Get Verification Flow
 
 This endpoint returns a verification flow's context with, for example, error details and other information.  Browser flows expect the anti-CSRF cookie to be included in the request's HTTP Cookie Header. For AJAX requests you must ensure that cookies are included in the request or requests will fail.  If you use the browser-flow for server-side apps, the services need to run on a common top-level-domain and you need to forward the incoming HTTP Cookie header to this endpoint:  ```js pseudo-code example router.get('/recovery', async function (req, res) { const flow = await client.getVerificationFlow(req.header('cookie'), req.query['flow'])  res.render('verification', flow) }) ```  More information can be found at [Ory Kratos Email and Phone Verification Documentation](https://www.ory.com/docs/kratos/self-service/flows/verify-email-account-activation).
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::frontend_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let id = "id_example"; // String | The Flow ID  The value for this parameter comes from `request` URL Query parameter sent to your application (e.g. `/verification?flow=abcde`).
+    let cookie = None; // String | HTTP Cookies  When using the SDK on the server side you must include the HTTP Cookie Header originally sent to your HTTP handler here. (optional)
+    match frontend_api::get_verification_flow(&configuration, id, cookie).await {
+        Ok(response) => println!("FrontendApi::get_verification_flow: {:?}", response),
+        Err(error) => eprintln!("Error calling FrontendApi::get_verification_flow: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -737,6 +1168,23 @@ Get WebAuthn JavaScript
 
 This endpoint provides JavaScript which is needed in order to perform WebAuthn login and registration.  If you are building a JavaScript Browser App (e.g. in ReactJS or AngularJS) you will need to load this file:  ```html <script src=\"https://public-kratos.example.org/.well-known/ory/webauthn.js\" type=\"script\" async /> ```  More information can be found at [Ory Kratos User Login](https://www.ory.com/docs/kratos/self-service/flows/user-login) and [User Registration Documentation](https://www.ory.com/docs/kratos/self-service/flows/user-registration).
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::frontend_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    match frontend_api::get_web_authn_java_script(&configuration).await {
+        Ok(response) => println!("FrontendApi::get_web_authn_java_script: {:?}", response),
+        Err(error) => eprintln!("Error calling FrontendApi::get_web_authn_java_script: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 This endpoint does not need any parameter.
@@ -764,6 +1212,23 @@ Change Password URL
 
 This endpoint implements the W3C \"change password URL\" well-known location by redirecting the browser to the configured settings UI. Password managers follow this redirect to take users straight to the page where they can change their password.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::frontend_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    match frontend_api::get_well_known_change_password(&configuration).await {
+        Ok(response) => println!("FrontendApi::get_well_known_change_password: {:?}", response),
+        Err(error) => eprintln!("Error calling FrontendApi::get_well_known_change_password: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 This endpoint does not need any parameter.
@@ -790,6 +1255,29 @@ No authorization required
 Get My Active Sessions
 
 This endpoints returns all other active sessions that belong to the logged-in user. The current session can be retrieved by calling the `/sessions/whoami` endpoint.
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::frontend_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let per_page = None; // i64 | Deprecated Items per Page  DEPRECATED: Please use `page_token` instead. This parameter will be removed in the future.  This is the number of items per page. (optional)
+    let page = None; // i64 | Deprecated Pagination Page  DEPRECATED: Please use `page_token` instead. This parameter will be removed in the future.  This value is currently an integer, but it is not sequential. The value is not the page number, but a reference. The next page can be any number and some numbers might return an empty list.  For example, page 2 might not follow after page 1. And even if page 3 and 5 exist, but page 4 might not exist. The first page can be retrieved by omitting this parameter. Following page pointers will be returned in the `Link` header. (optional)
+    let page_size = None; // i64 | Page Size  This is the number of items per page to return. For details on pagination please head over to the [pagination documentation](https://www.ory.com/docs/ecosystem/api-design#pagination). (optional)
+    let page_token = None; // String | Next Page Token  The next page token. For details on pagination please head over to the [pagination documentation](https://www.ory.com/docs/ecosystem/api-design#pagination). (optional)
+    let x_session_token = None; // String | Set the Session Token when calling from non-browser clients. A session token has a format of `MP2YWEMeM8MxjkGKpH4dqOQ4Q4DlSPaj`. (optional)
+    let cookie = None; // String | Set the Cookie Header. This is especially useful when calling this endpoint from a server-side application. In that scenario you must include the HTTP Cookie Header which originally was included in the request to your server. An example of a session in the HTTP Cookie Header is: `ory_kratos_session=a19iOVAbdzdgl70Rq1QZmrKmcjDtdsviCTZx7m9a9yHIUS8Wa9T7hvqyGTsLHi6Qifn2WUfpAKx9DWp0SJGleIn9vh2YF4A16id93kXFTgIgmwIOvbVAScyrx7yVl6bPZnCx27ec4WQDtaTewC1CpgudeDV2jQQnSaCP6ny3xa8qLH-QUgYqdQuoA_LF1phxgRCUfIrCLQOkolX5nv3ze_f==`.  It is ok if more than one cookie are included here as all other cookies will be ignored. (optional)
+    match frontend_api::list_my_sessions(&configuration, per_page, page, page_size, page_token, x_session_token, cookie).await {
+        Ok(response) => println!("FrontendApi::list_my_sessions: {:?}", response),
+        Err(error) => eprintln!("Error calling FrontendApi::list_my_sessions: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -826,6 +1314,24 @@ Perform Logout for Native Apps
 
 Use this endpoint to log out an identity using an Ory Session Token. If the Ory Session Token was successfully revoked, the server returns a 204 No Content response. A 204 No Content response is also sent when the Ory Session Token has been revoked already before.  If the Ory Session Token is malformed or does not exist a 403 Forbidden response will be returned.  This endpoint does not remove any HTTP Cookies - use the Browser-Based Self-Service Logout Flow instead.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::frontend_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let perform_native_logout_body = Default::default(); // PerformNativeLogoutBody
+    match frontend_api::perform_native_logout(&configuration, perform_native_logout_body).await {
+        Ok(_) => println!("FrontendApi::perform_native_logout"),
+        Err(error) => eprintln!("Error calling FrontendApi::perform_native_logout: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -855,6 +1361,26 @@ No authorization required
 Check Who the Current HTTP Session Belongs To
 
 Uses the HTTP Headers in the GET request to determine (e.g. by using checking the cookies) who is authenticated. Returns a session object in the body or 401 if the credentials are invalid or no credentials were sent. When the request it successful it adds the user ID to the 'X-Kratos-Authenticated-Identity-Id' header in the response.  If you call this endpoint from a server-side application, you must forward the HTTP Cookie Header to this endpoint:  ```js pseudo-code example router.get('/protected-endpoint', async function (req, res) { const session = await client.toSession(undefined, req.header('cookie'))  console.log(session) }) ```  When calling this endpoint from a non-browser application (e.g. mobile app) you must include the session token:  ```js pseudo-code example ... const session = await client.toSession(\"the-session-token\")  console.log(session) ```  When using a token template, the token is included in the `tokenized` field of the session.  ```js pseudo-code example ... const session = await client.toSession(\"the-session-token\", { tokenize_as: \"example-jwt-template\" })  console.log(session.tokenized) // The JWT ```  Depending on your configuration this endpoint might return a 403 status code if the session has a lower Authenticator Assurance Level (AAL) than is possible for the identity. This can happen if the identity has password + webauthn credentials (which would result in AAL2) but the session has only AAL1. If this error occurs, ask the user to sign in with the second factor or change the configuration.  This endpoint is useful for:  AJAX calls. Remember to send credentials and set up CORS correctly! Reverse proxies and API Gateways Server-side calls - use the `X-Session-Token` header!  This endpoint authenticates users by checking:  if the `Cookie` HTTP header was set containing an Ory Kratos Session Cookie; if the `Authorization: bearer <ory-session-token>` HTTP header was set with a valid Ory Kratos Session Token; if the `X-Session-Token` HTTP header was set with a valid Ory Kratos Session Token.  If none of these headers are set or the cookie or token are invalid, the endpoint returns a HTTP 401 status code.  As explained above, this request may fail due to several reasons. The `error.id` can be one of:  `session_inactive`: No active session was found in the request (e.g. no Ory Session Cookie / Ory Session Token). `session_aal2_required`: An active session was found but it does not fulfil the Authenticator Assurance Level, implying that the session must (e.g.) authenticate the second factor.
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::frontend_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let x_session_token = None; // String | Set the Session Token when calling from non-browser clients. A session token has a format of `MP2YWEMeM8MxjkGKpH4dqOQ4Q4DlSPaj`. (optional)
+    let cookie = None; // String | Set the Cookie Header. This is especially useful when calling this endpoint from a server-side application. In that scenario you must include the HTTP Cookie Header which originally was included in the request to your server. An example of a session in the HTTP Cookie Header is: `ory_kratos_session=a19iOVAbdzdgl70Rq1QZmrKmcjDtdsviCTZx7m9a9yHIUS8Wa9T7hvqyGTsLHi6Qifn2WUfpAKx9DWp0SJGleIn9vh2YF4A16id93kXFTgIgmwIOvbVAScyrx7yVl6bPZnCx27ec4WQDtaTewC1CpgudeDV2jQQnSaCP6ny3xa8qLH-QUgYqdQuoA_LF1phxgRCUfIrCLQOkolX5nv3ze_f==`.  It is ok if more than one cookie are included here as all other cookies will be ignored. (optional)
+    let tokenize_as = None; // String | Returns the session additionally as a token (such as a JWT)  The value of this parameter has to be a valid, configured Ory Session token template. For more information head over to [the documentation](http://ory.sh/docs/identities/session-to-jwt-cors). (optional)
+    match frontend_api::to_session(&configuration, x_session_token, cookie, tokenize_as).await {
+        Ok(response) => println!("FrontendApi::to_session: {:?}", response),
+        Err(error) => eprintln!("Error calling FrontendApi::to_session: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -888,6 +1414,24 @@ Submit a FedCM token
 
 Use this endpoint to submit a token from a FedCM provider through `navigator.credentials.get` and log the user in. The parameters from `navigator.credentials.get` must have come from `GET self-service/fed-cm/parameters`.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::frontend_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let update_fedcm_flow_body = Default::default(); // UpdateFedcmFlowBody
+    match frontend_api::update_fedcm_flow(&configuration, update_fedcm_flow_body).await {
+        Ok(response) => println!("FrontendApi::update_fedcm_flow: {:?}", response),
+        Err(error) => eprintln!("Error calling FrontendApi::update_fedcm_flow: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -917,6 +1461,27 @@ No authorization required
 Submit a Login Flow
 
 Use this endpoint to complete a login flow. This endpoint behaves differently for API and browser flows.  API flows expect `application/json` to be sent in the body and responds with HTTP 200 and a application/json body with the session token on success; HTTP 410 if the original flow expired with the appropriate error messages set and optionally a `use_flow_id` parameter in the body; HTTP 400 on form validation errors.  Browser flows expect a Content-Type of `application/x-www-form-urlencoded` or `application/json` to be sent in the body and respond with a HTTP 303 redirect to the post/after login URL or the `return_to` value if it was set and if the login succeeded; a HTTP 303 redirect to the login UI URL with the flow ID containing the validation errors otherwise.  Browser flows with an accept header of `application/json` will not redirect but instead respond with HTTP 200 and a application/json body with the signed in identity and a `Set-Cookie` header on success; HTTP 303 redirect to a fresh login flow if the original flow expired with the appropriate error messages set; HTTP 400 on form validation errors.  If this endpoint is called with `Accept: application/json` in the header, the response contains the flow without a redirect. In the case of an error, the `error.id` of the JSON response body can be one of:  `session_already_available`: The user is already signed in. `security_csrf_violation`: Unable to fetch the flow because a CSRF violation occurred. `security_identity_mismatch`: The requested `?return_to` address is not allowed to be used. Adjust this in the configuration! `browser_location_change_required`: Usually sent when an AJAX request indicates that the browser needs to open a specific URL. Most likely used in Social Sign In flows.  More information can be found at [Ory Kratos User Login](https://www.ory.com/docs/kratos/self-service/flows/user-login) and [User Registration Documentation](https://www.ory.com/docs/kratos/self-service/flows/user-registration).
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::frontend_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let flow = "flow_example"; // String | The Login Flow ID  The value for this parameter comes from `flow` URL Query parameter sent to your application (e.g. `/login?flow=abcde`).
+    let update_login_flow_body = Default::default(); // UpdateLoginFlowBody
+    let x_session_token = None; // String | The Session Token of the Identity performing the settings flow. (optional)
+    let cookie = None; // String | HTTP Cookies  When using the SDK in a browser app, on the server side you must include the HTTP Cookie Header sent by the client to your server here. This ensures that CSRF and session cookies are respected. (optional)
+    match frontend_api::update_login_flow(&configuration, flow, update_login_flow_body, x_session_token, cookie).await {
+        Ok(response) => println!("FrontendApi::update_login_flow: {:?}", response),
+        Err(error) => eprintln!("Error calling FrontendApi::update_login_flow: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -951,6 +1516,26 @@ Update Logout Flow
 
 This endpoint logs out an identity in a self-service manner.  If the `Accept` HTTP header is not set to `application/json`, the browser will be redirected (HTTP 303 See Other) to the `return_to` parameter of the initial request or fall back to `urls.default_return_to`.  If the `Accept` HTTP header is set to `application/json`, a 204 No Content response will be sent on successful logout instead.  This endpoint is NOT INTENDED for API clients and only works with browsers (Chrome, Firefox, ...). For API clients you can call the `/self-service/logout/api` URL directly with the Ory Session Token.  More information can be found at [Ory Kratos User Logout Documentation](https://www.ory.com/docs/next/kratos/self-service/flows/user-logout).
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::frontend_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let token = None; // String | A Valid Logout Token  If you do not have a logout token because you only have a session cookie, call `/self-service/logout/browser` to generate a URL for this endpoint. (optional)
+    let return_to = None; // String | The URL to return to after the logout was completed. (optional)
+    let cookie = None; // String | HTTP Cookies  When using the SDK in a browser app, on the server side you must include the HTTP Cookie Header sent by the client to your server here. This ensures that CSRF and session cookies are respected. (optional)
+    match frontend_api::update_logout_flow(&configuration, token, return_to, cookie).await {
+        Ok(_) => println!("FrontendApi::update_logout_flow"),
+        Err(error) => eprintln!("Error calling FrontendApi::update_logout_flow: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -982,6 +1567,27 @@ No authorization required
 Update Recovery Flow
 
 Use this endpoint to update a recovery flow. This endpoint behaves differently for API and browser flows and has several states:  `choose_method` expects `flow` (in the URL query) and `email` (in the body) to be sent and works with API- and Browser-initiated flows. For API clients and Browser clients with HTTP Header `Accept: application/json` it either returns a HTTP 200 OK when the form is valid and HTTP 400 OK when the form is invalid. and a HTTP 303 See Other redirect with a fresh recovery flow if the flow was otherwise invalid (e.g. expired). For Browser clients without HTTP Header `Accept` or with `Accept: text/_*` it returns a HTTP 303 See Other redirect to the Recovery UI URL with the Recovery Flow ID appended. `sent_email` is the success state after `choose_method` for the `link` method and allows the user to request another recovery email. It works for both API and Browser-initiated flows and returns the same responses as the flow in `choose_method` state. `passed_challenge` expects a `token` to be sent in the URL query and given the nature of the flow (\"sending a recovery link\") does not have any API capabilities. The server responds with a HTTP 303 See Other redirect either to the Settings UI URL (if the link was valid) and instructs the user to update their password, or a redirect to the Recover UI URL with a new Recovery Flow ID which contains an error message that the recovery link was invalid.  More information can be found at [Ory Kratos Account Recovery Documentation](../self-service/flows/account-recovery).
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::frontend_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let flow = "flow_example"; // String | The Recovery Flow ID  The value for this parameter comes from `flow` URL Query parameter sent to your application (e.g. `/recovery?flow=abcde`).
+    let update_recovery_flow_body = Default::default(); // UpdateRecoveryFlowBody
+    let token = None; // String | Recovery Token  The recovery token which completes the recovery request. If the token is invalid (e.g. expired) an error will be shown to the end-user.  This parameter is usually set in a link and not used by any direct API call. (optional)
+    let cookie = None; // String | HTTP Cookies  When using the SDK in a browser app, on the server side you must include the HTTP Cookie Header sent by the client to your server here. This ensures that CSRF and session cookies are respected. (optional)
+    match frontend_api::update_recovery_flow(&configuration, flow, update_recovery_flow_body, token, cookie).await {
+        Ok(response) => println!("FrontendApi::update_recovery_flow: {:?}", response),
+        Err(error) => eprintln!("Error calling FrontendApi::update_recovery_flow: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -1016,6 +1622,26 @@ Update Registration Flow
 
 Use this endpoint to complete a registration flow by sending an identity's traits and password. This endpoint behaves differently for API and browser flows.  API flows expect `application/json` to be sent in the body and respond with HTTP 200 and a application/json body with the created identity success - if the session hook is configured the `session` and `session_token` will also be included; HTTP 410 if the original flow expired with the appropriate error messages set and optionally a `use_flow_id` parameter in the body; HTTP 400 on form validation errors.  Browser flows expect a Content-Type of `application/x-www-form-urlencoded` or `application/json` to be sent in the body and respond with a HTTP 303 redirect to the post/after registration URL or the `return_to` value if it was set and if the registration succeeded; a HTTP 303 redirect to the registration UI URL with the flow ID containing the validation errors otherwise.  Browser flows with an accept header of `application/json` will not redirect but instead respond with HTTP 200 and a application/json body with the signed in identity and a `Set-Cookie` header on success; HTTP 303 redirect to a fresh login flow if the original flow expired with the appropriate error messages set; HTTP 400 on form validation errors.  If this endpoint is called with `Accept: application/json` in the header, the response contains the flow without a redirect. In the case of an error, the `error.id` of the JSON response body can be one of:  `session_already_available`: The user is already signed in. `security_csrf_violation`: Unable to fetch the flow because a CSRF violation occurred. `security_identity_mismatch`: The requested `?return_to` address is not allowed to be used. Adjust this in the configuration! `browser_location_change_required`: Usually sent when an AJAX request indicates that the browser needs to open a specific URL. Most likely used in Social Sign In flows.  More information can be found at [Ory Kratos User Login](https://www.ory.com/docs/kratos/self-service/flows/user-login) and [User Registration Documentation](https://www.ory.com/docs/kratos/self-service/flows/user-registration).
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::frontend_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let flow = "flow_example"; // String | The Registration Flow ID  The value for this parameter comes from `flow` URL Query parameter sent to your application (e.g. `/registration?flow=abcde`).
+    let update_registration_flow_body = Default::default(); // UpdateRegistrationFlowBody
+    let cookie = None; // String | HTTP Cookies  When using the SDK in a browser app, on the server side you must include the HTTP Cookie Header sent by the client to your server here. This ensures that CSRF and session cookies are respected. (optional)
+    match frontend_api::update_registration_flow(&configuration, flow, update_registration_flow_body, cookie).await {
+        Ok(response) => println!("FrontendApi::update_registration_flow: {:?}", response),
+        Err(error) => eprintln!("Error calling FrontendApi::update_registration_flow: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -1047,6 +1673,27 @@ No authorization required
 Complete Settings Flow
 
 Use this endpoint to complete a settings flow by sending an identity's updated password. This endpoint behaves differently for API and browser flows.  API-initiated flows expect `application/json` to be sent in the body and respond with HTTP 200 and an application/json body with the session token on success; HTTP 303 redirect to a fresh settings flow if the original flow expired with the appropriate error messages set; HTTP 400 on form validation errors. HTTP 401 when the endpoint is called without a valid session token. HTTP 403 when `selfservice.flows.settings.privileged_session_max_age` was reached or the session's AAL is too low. Implies that the user needs to re-authenticate.  Browser flows without HTTP Header `Accept` or with `Accept: text/_*` respond with a HTTP 303 redirect to the post/after settings URL or the `return_to` value if it was set and if the flow succeeded; a HTTP 303 redirect to the Settings UI URL with the flow ID containing the validation errors otherwise. a HTTP 303 redirect to the login endpoint when `selfservice.flows.settings.privileged_session_max_age` was reached or the session's AAL is too low.  Browser flows with HTTP Header `Accept: application/json` respond with HTTP 200 and a application/json body with the signed in identity and a `Set-Cookie` header on success; HTTP 303 redirect to a fresh login flow if the original flow expired with the appropriate error messages set; HTTP 401 when the endpoint is called without a valid session cookie. HTTP 403 when the page is accessed without a session cookie or the session's AAL is too low. HTTP 400 on form validation errors.  Depending on your configuration this endpoint might return a 403 error if the session has a lower Authenticator Assurance Level (AAL) than is possible for the identity. This can happen if the identity has password + webauthn credentials (which would result in AAL2) but the session has only AAL1. If this error occurs, ask the user to sign in with the second factor (happens automatically for server-side browser flows) or change the configuration.  If this endpoint is called with a `Accept: application/json` HTTP header, the response contains the flow without a redirect. In the case of an error, the `error.id` of the JSON response body can be one of:  `session_refresh_required`: The identity requested to change something that needs a privileged session. Redirect the identity to the login init endpoint with query parameters `?refresh=true&return_to=<the-current-browser-url>`, or initiate a refresh login flow otherwise. `security_csrf_violation`: Unable to fetch the flow because a CSRF violation occurred. `session_inactive`: No Ory Session was found - sign in a user first. `security_identity_mismatch`: The flow was interrupted with `session_refresh_required` but apparently some other identity logged in instead. `security_identity_mismatch`: The requested `?return_to` address is not allowed to be used. Adjust this in the configuration! `browser_location_change_required`: Usually sent when an AJAX request indicates that the browser needs to open a specific URL. Most likely used in Social Sign In flows.  More information can be found at [Ory Kratos User Settings & Profile Management Documentation](../self-service/flows/user-settings).
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::frontend_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let flow = "flow_example"; // String | The Settings Flow ID  The value for this parameter comes from `flow` URL Query parameter sent to your application (e.g. `/settings?flow=abcde`).
+    let update_settings_flow_body = Default::default(); // UpdateSettingsFlowBody
+    let x_session_token = None; // String | The Session Token of the Identity performing the settings flow. (optional)
+    let cookie = None; // String | HTTP Cookies  When using the SDK in a browser app, on the server side you must include the HTTP Cookie Header sent by the client to your server here. This ensures that CSRF and session cookies are respected. (optional)
+    match frontend_api::update_settings_flow(&configuration, flow, update_settings_flow_body, x_session_token, cookie).await {
+        Ok(response) => println!("FrontendApi::update_settings_flow: {:?}", response),
+        Err(error) => eprintln!("Error calling FrontendApi::update_settings_flow: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -1080,6 +1727,27 @@ No authorization required
 Complete Verification Flow
 
 Use this endpoint to complete a verification flow. This endpoint behaves differently for API and browser flows and has several states:  `choose_method` expects `flow` (in the URL query) and `email` (in the body) to be sent and works with API- and Browser-initiated flows. For API clients and Browser clients with HTTP Header `Accept: application/json` it either returns a HTTP 200 OK when the form is valid and HTTP 400 OK when the form is invalid and a HTTP 303 See Other redirect with a fresh verification flow if the flow was otherwise invalid (e.g. expired). For Browser clients without HTTP Header `Accept` or with `Accept: text/_*` it returns a HTTP 303 See Other redirect to the Verification UI URL with the Verification Flow ID appended. `sent_email` is the success state after `choose_method` when using the `link` method and allows the user to request another verification email. It works for both API and Browser-initiated flows and returns the same responses as the flow in `choose_method` state. `passed_challenge` expects a `token` to be sent in the URL query and given the nature of the flow (\"sending a verification link\") does not have any API capabilities. The server responds with a HTTP 303 See Other redirect either to the Settings UI URL (if the link was valid) and instructs the user to update their password, or a redirect to the Verification UI URL with a new Verification Flow ID which contains an error message that the verification link was invalid.  More information can be found at [Ory Kratos Email and Phone Verification Documentation](https://www.ory.com/docs/kratos/self-service/flows/verify-email-account-activation).
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::frontend_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let flow = "flow_example"; // String | The Verification Flow ID  The value for this parameter comes from `flow` URL Query parameter sent to your application (e.g. `/verification?flow=abcde`).
+    let update_verification_flow_body = Default::default(); // UpdateVerificationFlowBody
+    let token = None; // String | Verification Token  The verification token which completes the verification request. If the token is invalid (e.g. expired) an error will be shown to the end-user.  This parameter is usually set in a link and not used by any direct API call. (optional)
+    let cookie = None; // String | HTTP Cookies  When using the SDK in a browser app, on the server side you must include the HTTP Cookie Header sent by the client to your server here. This ensures that CSRF and session cookies are respected. (optional)
+    match frontend_api::update_verification_flow(&configuration, flow, update_verification_flow_body, token, cookie).await {
+        Ok(response) => println!("FrontendApi::update_verification_flow: {:?}", response),
+        Err(error) => eprintln!("Error calling FrontendApi::update_verification_flow: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 

--- a/clients/client/rust/docs/FrontendApi.md
+++ b/clients/client/rust/docs/FrontendApi.md
@@ -57,7 +57,6 @@ use ory_client::apis::frontend_api;
 #[tokio::main]
 async fn main() {
     let mut configuration = Configuration::new();
-    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
     let refresh = None; // bool | Refresh a login session  If set to true, this will refresh an existing login session by asking the user to sign in again. This will reset the authenticated_at time of the session. (optional)
     let aal = None; // String | Request a Specific AuthenticationMethod Assurance Level  Use this parameter to upgrade an existing session's authenticator assurance level (AAL). This allows you to ask for multi-factor authentication. When an identity sign in using e.g. username+password, the AAL is 1. If you wish to \"upgrade\" the session's security by asking the user to perform TOTP / WebAuth/ ... you would set this to \"aal2\". (optional)
     let return_to = None; // String | The URL to return the browser to after the flow was completed. (optional)
@@ -119,7 +118,6 @@ use ory_client::apis::frontend_api;
 #[tokio::main]
 async fn main() {
     let mut configuration = Configuration::new();
-    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
     let cookie = None; // String | HTTP Cookies  If you call this endpoint from a backend, please include the original Cookie header in the request. (optional)
     let return_to = None; // String | Return to URL  The URL to which the browser should be redirected to after the logout has been performed. (optional)
     match frontend_api::create_browser_logout_flow(&configuration, cookie, return_to).await {
@@ -169,7 +167,6 @@ use ory_client::apis::frontend_api;
 #[tokio::main]
 async fn main() {
     let mut configuration = Configuration::new();
-    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
     let return_to = None; // String | The URL to return the browser to after the flow was completed. (optional)
     let skip_settings = None; // String | Skip redirection to the settings UI after the recovery flow was completed. Instead, the user will be redirected to the URL specified in `return_to` query parameter or the default return URL if `return_to` is not set. (optional)
     match frontend_api::create_browser_recovery_flow(&configuration, return_to, skip_settings).await {
@@ -219,7 +216,6 @@ use ory_client::apis::frontend_api;
 #[tokio::main]
 async fn main() {
     let mut configuration = Configuration::new();
-    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
     let return_to = None; // String | The URL to return the browser to after the flow was completed. (optional)
     let login_challenge = None; // String | Ory OAuth 2.0 Login Challenge.  If set will cooperate with Ory OAuth2 and OpenID to act as an OAuth2 server / OpenID Provider.  The value for this parameter comes from `login_challenge` URL Query parameter sent to your application (e.g. `/registration?login_challenge=abcde`).  This feature is compatible with Ory Hydra when not running on the Ory Network. (optional)
     let after_verification_return_to = None; // String | The URL to return the browser to after the verification flow was completed.  After the registration flow is completed, the user will be sent a verification email. Upon completing the verification flow, this URL will be used to override the default `selfservice.flows.verification.after.default_redirect_to` value. (optional)
@@ -275,7 +271,6 @@ use ory_client::apis::frontend_api;
 #[tokio::main]
 async fn main() {
     let mut configuration = Configuration::new();
-    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
     let return_to = None; // String | The URL to return the browser to after the flow was completed. (optional)
     let cookie = None; // String | HTTP Cookies  When using the SDK in a browser app, on the server side you must include the HTTP Cookie Header sent by the client to your server here. This ensures that CSRF and session cookies are respected. (optional)
     let organization = None; // String | An optional organization ID that scopes the settings flow to providers of that organization. This parameter is only effective in the Ory Network. (optional)
@@ -327,7 +322,6 @@ use ory_client::apis::frontend_api;
 #[tokio::main]
 async fn main() {
     let mut configuration = Configuration::new();
-    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
     let return_to = None; // String | The URL to return the browser to after the flow was completed. (optional)
     match frontend_api::create_browser_verification_flow(&configuration, return_to).await {
         Ok(response) => println!("FrontendApi::create_browser_verification_flow: {:?}", response),
@@ -375,7 +369,6 @@ use ory_client::apis::frontend_api;
 #[tokio::main]
 async fn main() {
     let mut configuration = Configuration::new();
-    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
     match frontend_api::create_fedcm_flow(&configuration).await {
         Ok(response) => println!("FrontendApi::create_fedcm_flow: {:?}", response),
         Err(error) => eprintln!("Error calling FrontendApi::create_fedcm_flow: {:?}", error),
@@ -419,7 +412,6 @@ use ory_client::apis::frontend_api;
 #[tokio::main]
 async fn main() {
     let mut configuration = Configuration::new();
-    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
     let refresh = None; // bool | Refresh a login session  If set to true, this will refresh an existing login session by asking the user to sign in again. This will reset the authenticated_at time of the session. (optional)
     let aal = None; // String | Request a Specific AuthenticationMethod Assurance Level  Use this parameter to upgrade an existing session's authenticator assurance level (AAL). This allows you to ask for multi-factor authentication. When an identity sign in using e.g. username+password, the AAL is 1. If you wish to \"upgrade\" the session's security by asking the user to perform TOTP / WebAuth/ ... you would set this to \"aal2\". (optional)
     let x_session_token = None; // String | The Session Token of the Identity performing the settings flow. (optional)
@@ -481,7 +473,6 @@ use ory_client::apis::frontend_api;
 #[tokio::main]
 async fn main() {
     let mut configuration = Configuration::new();
-    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
     match frontend_api::create_native_recovery_flow(&configuration).await {
         Ok(response) => println!("FrontendApi::create_native_recovery_flow: {:?}", response),
         Err(error) => eprintln!("Error calling FrontendApi::create_native_recovery_flow: {:?}", error),
@@ -525,7 +516,6 @@ use ory_client::apis::frontend_api;
 #[tokio::main]
 async fn main() {
     let mut configuration = Configuration::new();
-    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
     let return_session_token_exchange_code = None; // bool | EnableSessionTokenExchangeCode requests the login flow to include a code that can be used to retrieve the session token after the login flow has been completed. (optional)
     let return_to = None; // String | The URL to return the browser to after the flow was completed. (optional)
     let organization = None; // String | An optional organization ID that should be used to register this user. This parameter is only effective in the Ory Network. (optional)
@@ -579,7 +569,6 @@ use ory_client::apis::frontend_api;
 #[tokio::main]
 async fn main() {
     let mut configuration = Configuration::new();
-    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
     let x_session_token = None; // String | The Session Token of the Identity performing the settings flow. (optional)
     let organization = None; // String | An optional organization ID that scopes the settings flow to providers of that organization. This parameter is only effective in the Ory Network. (optional)
     match frontend_api::create_native_settings_flow(&configuration, x_session_token, organization).await {
@@ -629,7 +618,6 @@ use ory_client::apis::frontend_api;
 #[tokio::main]
 async fn main() {
     let mut configuration = Configuration::new();
-    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
     let return_to = None; // String | A URL contained in the return_to key of the verification flow. This piece of data has no effect on the actual logic of the flow and is purely informational. (optional)
     match frontend_api::create_native_verification_flow(&configuration, return_to).await {
         Ok(response) => println!("FrontendApi::create_native_verification_flow: {:?}", response),
@@ -677,7 +665,6 @@ use ory_client::apis::frontend_api;
 #[tokio::main]
 async fn main() {
     let mut configuration = Configuration::new();
-    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
     let id = "id_example"; // String | ID of the test login flow to delete.
     let cookie = None; // String | HTTP Cookies. A captured test flow requires the ory_kratos_test_flow cookie set by the OIDC callback; a flow still in the initial choose-method state does not. (optional)
     match frontend_api::delete_test_login_flow(&configuration, id, cookie).await {
@@ -727,7 +714,6 @@ use ory_client::apis::frontend_api;
 #[tokio::main]
 async fn main() {
     let mut configuration = Configuration::new();
-    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
     let x_session_token = None; // String | Set the Session Token when calling from non-browser clients. A session token has a format of `MP2YWEMeM8MxjkGKpH4dqOQ4Q4DlSPaj`. (optional)
     let cookie = None; // String | Set the Cookie Header. This is especially useful when calling this endpoint from a server-side application. In that scenario you must include the HTTP Cookie Header which originally was included in the request to your server. An example of a session in the HTTP Cookie Header is: `ory_kratos_session=a19iOVAbdzdgl70Rq1QZmrKmcjDtdsviCTZx7m9a9yHIUS8Wa9T7hvqyGTsLHi6Qifn2WUfpAKx9DWp0SJGleIn9vh2YF4A16id93kXFTgIgmwIOvbVAScyrx7yVl6bPZnCx27ec4WQDtaTewC1CpgudeDV2jQQnSaCP6ny3xa8qLH-QUgYqdQuoA_LF1phxgRCUfIrCLQOkolX5nv3ze_f==`.  It is ok if more than one cookie are included here as all other cookies will be ignored. (optional)
     match frontend_api::disable_my_other_sessions(&configuration, x_session_token, cookie).await {
@@ -777,7 +763,6 @@ use ory_client::apis::frontend_api;
 #[tokio::main]
 async fn main() {
     let mut configuration = Configuration::new();
-    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
     let id = "id_example"; // String | ID is the session's ID.
     let x_session_token = None; // String | Set the Session Token when calling from non-browser clients. A session token has a format of `MP2YWEMeM8MxjkGKpH4dqOQ4Q4DlSPaj`. (optional)
     let cookie = None; // String | Set the Cookie Header. This is especially useful when calling this endpoint from a server-side application. In that scenario you must include the HTTP Cookie Header which originally was included in the request to your server. An example of a session in the HTTP Cookie Header is: `ory_kratos_session=a19iOVAbdzdgl70Rq1QZmrKmcjDtdsviCTZx7m9a9yHIUS8Wa9T7hvqyGTsLHi6Qifn2WUfpAKx9DWp0SJGleIn9vh2YF4A16id93kXFTgIgmwIOvbVAScyrx7yVl6bPZnCx27ec4WQDtaTewC1CpgudeDV2jQQnSaCP6ny3xa8qLH-QUgYqdQuoA_LF1phxgRCUfIrCLQOkolX5nv3ze_f==`.  It is ok if more than one cookie are included here as all other cookies will be ignored. (optional)
@@ -827,7 +812,6 @@ use ory_client::apis::frontend_api;
 #[tokio::main]
 async fn main() {
     let mut configuration = Configuration::new();
-    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
     let init_code = "init_code_example"; // String | The part of the code return when initializing the flow.
     let return_to_code = "return_to_code_example"; // String | The part of the code returned by the return_to URL.
     match frontend_api::exchange_session_token(&configuration, init_code, return_to_code).await {
@@ -877,7 +861,6 @@ use ory_client::apis::frontend_api;
 #[tokio::main]
 async fn main() {
     let mut configuration = Configuration::new();
-    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
     let id = "id_example"; // String | Error is the error's ID
     match frontend_api::get_flow_error(&configuration, id).await {
         Ok(response) => println!("FrontendApi::get_flow_error: {:?}", response),
@@ -925,7 +908,6 @@ use ory_client::apis::frontend_api;
 #[tokio::main]
 async fn main() {
     let mut configuration = Configuration::new();
-    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
     let id = "id_example"; // String | The Login Flow ID  The value for this parameter comes from `flow` URL Query parameter sent to your application (e.g. `/login?flow=abcde`).
     let cookie = None; // String | HTTP Cookies  When using the SDK in a browser app, on the server side you must include the HTTP Cookie Header sent by the client to your server here. This ensures that CSRF and session cookies are respected. (optional)
     match frontend_api::get_login_flow(&configuration, id, cookie).await {
@@ -975,7 +957,6 @@ use ory_client::apis::frontend_api;
 #[tokio::main]
 async fn main() {
     let mut configuration = Configuration::new();
-    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
     let id = "id_example"; // String | The Flow ID  The value for this parameter comes from `request` URL Query parameter sent to your application (e.g. `/recovery?flow=abcde`).
     let cookie = None; // String | HTTP Cookies  When using the SDK in a browser app, on the server side you must include the HTTP Cookie Header sent by the client to your server here. This ensures that CSRF and session cookies are respected. (optional)
     match frontend_api::get_recovery_flow(&configuration, id, cookie).await {
@@ -1025,7 +1006,6 @@ use ory_client::apis::frontend_api;
 #[tokio::main]
 async fn main() {
     let mut configuration = Configuration::new();
-    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
     let id = "id_example"; // String | The Registration Flow ID  The value for this parameter comes from `flow` URL Query parameter sent to your application (e.g. `/registration?flow=abcde`).
     let cookie = None; // String | HTTP Cookies  When using the SDK in a browser app, on the server side you must include the HTTP Cookie Header sent by the client to your server here. This ensures that CSRF and session cookies are respected. (optional)
     match frontend_api::get_registration_flow(&configuration, id, cookie).await {
@@ -1075,7 +1055,6 @@ use ory_client::apis::frontend_api;
 #[tokio::main]
 async fn main() {
     let mut configuration = Configuration::new();
-    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
     let id = "id_example"; // String | ID is the Settings Flow ID  The value for this parameter comes from `flow` URL Query parameter sent to your application (e.g. `/settings?flow=abcde`).
     let x_session_token = None; // String | The Session Token  When using the SDK in an app without a browser, please include the session token here. (optional)
     let cookie = None; // String | HTTP Cookies  When using the SDK in a browser app, on the server side you must include the HTTP Cookie Header sent by the client to your server here. This ensures that CSRF and session cookies are respected. (optional)
@@ -1127,7 +1106,6 @@ use ory_client::apis::frontend_api;
 #[tokio::main]
 async fn main() {
     let mut configuration = Configuration::new();
-    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
     let id = "id_example"; // String | The Flow ID  The value for this parameter comes from `request` URL Query parameter sent to your application (e.g. `/verification?flow=abcde`).
     let cookie = None; // String | HTTP Cookies  When using the SDK on the server side you must include the HTTP Cookie Header originally sent to your HTTP handler here. (optional)
     match frontend_api::get_verification_flow(&configuration, id, cookie).await {
@@ -1177,7 +1155,6 @@ use ory_client::apis::frontend_api;
 #[tokio::main]
 async fn main() {
     let mut configuration = Configuration::new();
-    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
     match frontend_api::get_web_authn_java_script(&configuration).await {
         Ok(response) => println!("FrontendApi::get_web_authn_java_script: {:?}", response),
         Err(error) => eprintln!("Error calling FrontendApi::get_web_authn_java_script: {:?}", error),
@@ -1221,7 +1198,6 @@ use ory_client::apis::frontend_api;
 #[tokio::main]
 async fn main() {
     let mut configuration = Configuration::new();
-    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
     match frontend_api::get_well_known_change_password(&configuration).await {
         Ok(response) => println!("FrontendApi::get_well_known_change_password: {:?}", response),
         Err(error) => eprintln!("Error calling FrontendApi::get_well_known_change_password: {:?}", error),
@@ -1265,7 +1241,6 @@ use ory_client::apis::frontend_api;
 #[tokio::main]
 async fn main() {
     let mut configuration = Configuration::new();
-    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
     let per_page = None; // i64 | Deprecated Items per Page  DEPRECATED: Please use `page_token` instead. This parameter will be removed in the future.  This is the number of items per page. (optional)
     let page = None; // i64 | Deprecated Pagination Page  DEPRECATED: Please use `page_token` instead. This parameter will be removed in the future.  This value is currently an integer, but it is not sequential. The value is not the page number, but a reference. The next page can be any number and some numbers might return an empty list.  For example, page 2 might not follow after page 1. And even if page 3 and 5 exist, but page 4 might not exist. The first page can be retrieved by omitting this parameter. Following page pointers will be returned in the `Link` header. (optional)
     let page_size = None; // i64 | Page Size  This is the number of items per page to return. For details on pagination please head over to the [pagination documentation](https://www.ory.com/docs/ecosystem/api-design#pagination). (optional)
@@ -1323,7 +1298,6 @@ use ory_client::apis::frontend_api;
 #[tokio::main]
 async fn main() {
     let mut configuration = Configuration::new();
-    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
     let perform_native_logout_body = Default::default(); // PerformNativeLogoutBody
     match frontend_api::perform_native_logout(&configuration, perform_native_logout_body).await {
         Ok(_) => println!("FrontendApi::perform_native_logout"),
@@ -1371,7 +1345,6 @@ use ory_client::apis::frontend_api;
 #[tokio::main]
 async fn main() {
     let mut configuration = Configuration::new();
-    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
     let x_session_token = None; // String | Set the Session Token when calling from non-browser clients. A session token has a format of `MP2YWEMeM8MxjkGKpH4dqOQ4Q4DlSPaj`. (optional)
     let cookie = None; // String | Set the Cookie Header. This is especially useful when calling this endpoint from a server-side application. In that scenario you must include the HTTP Cookie Header which originally was included in the request to your server. An example of a session in the HTTP Cookie Header is: `ory_kratos_session=a19iOVAbdzdgl70Rq1QZmrKmcjDtdsviCTZx7m9a9yHIUS8Wa9T7hvqyGTsLHi6Qifn2WUfpAKx9DWp0SJGleIn9vh2YF4A16id93kXFTgIgmwIOvbVAScyrx7yVl6bPZnCx27ec4WQDtaTewC1CpgudeDV2jQQnSaCP6ny3xa8qLH-QUgYqdQuoA_LF1phxgRCUfIrCLQOkolX5nv3ze_f==`.  It is ok if more than one cookie are included here as all other cookies will be ignored. (optional)
     let tokenize_as = None; // String | Returns the session additionally as a token (such as a JWT)  The value of this parameter has to be a valid, configured Ory Session token template. For more information head over to [the documentation](http://ory.sh/docs/identities/session-to-jwt-cors). (optional)
@@ -1423,7 +1396,6 @@ use ory_client::apis::frontend_api;
 #[tokio::main]
 async fn main() {
     let mut configuration = Configuration::new();
-    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
     let update_fedcm_flow_body = Default::default(); // UpdateFedcmFlowBody
     match frontend_api::update_fedcm_flow(&configuration, update_fedcm_flow_body).await {
         Ok(response) => println!("FrontendApi::update_fedcm_flow: {:?}", response),
@@ -1471,7 +1443,6 @@ use ory_client::apis::frontend_api;
 #[tokio::main]
 async fn main() {
     let mut configuration = Configuration::new();
-    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
     let flow = "flow_example"; // String | The Login Flow ID  The value for this parameter comes from `flow` URL Query parameter sent to your application (e.g. `/login?flow=abcde`).
     let update_login_flow_body = Default::default(); // UpdateLoginFlowBody
     let x_session_token = None; // String | The Session Token of the Identity performing the settings flow. (optional)
@@ -1525,7 +1496,6 @@ use ory_client::apis::frontend_api;
 #[tokio::main]
 async fn main() {
     let mut configuration = Configuration::new();
-    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
     let token = None; // String | A Valid Logout Token  If you do not have a logout token because you only have a session cookie, call `/self-service/logout/browser` to generate a URL for this endpoint. (optional)
     let return_to = None; // String | The URL to return to after the logout was completed. (optional)
     let cookie = None; // String | HTTP Cookies  When using the SDK in a browser app, on the server side you must include the HTTP Cookie Header sent by the client to your server here. This ensures that CSRF and session cookies are respected. (optional)
@@ -1577,7 +1547,6 @@ use ory_client::apis::frontend_api;
 #[tokio::main]
 async fn main() {
     let mut configuration = Configuration::new();
-    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
     let flow = "flow_example"; // String | The Recovery Flow ID  The value for this parameter comes from `flow` URL Query parameter sent to your application (e.g. `/recovery?flow=abcde`).
     let update_recovery_flow_body = Default::default(); // UpdateRecoveryFlowBody
     let token = None; // String | Recovery Token  The recovery token which completes the recovery request. If the token is invalid (e.g. expired) an error will be shown to the end-user.  This parameter is usually set in a link and not used by any direct API call. (optional)
@@ -1631,7 +1600,6 @@ use ory_client::apis::frontend_api;
 #[tokio::main]
 async fn main() {
     let mut configuration = Configuration::new();
-    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
     let flow = "flow_example"; // String | The Registration Flow ID  The value for this parameter comes from `flow` URL Query parameter sent to your application (e.g. `/registration?flow=abcde`).
     let update_registration_flow_body = Default::default(); // UpdateRegistrationFlowBody
     let cookie = None; // String | HTTP Cookies  When using the SDK in a browser app, on the server side you must include the HTTP Cookie Header sent by the client to your server here. This ensures that CSRF and session cookies are respected. (optional)
@@ -1683,7 +1651,6 @@ use ory_client::apis::frontend_api;
 #[tokio::main]
 async fn main() {
     let mut configuration = Configuration::new();
-    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
     let flow = "flow_example"; // String | The Settings Flow ID  The value for this parameter comes from `flow` URL Query parameter sent to your application (e.g. `/settings?flow=abcde`).
     let update_settings_flow_body = Default::default(); // UpdateSettingsFlowBody
     let x_session_token = None; // String | The Session Token of the Identity performing the settings flow. (optional)
@@ -1737,7 +1704,6 @@ use ory_client::apis::frontend_api;
 #[tokio::main]
 async fn main() {
     let mut configuration = Configuration::new();
-    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
     let flow = "flow_example"; // String | The Verification Flow ID  The value for this parameter comes from `flow` URL Query parameter sent to your application (e.g. `/verification?flow=abcde`).
     let update_verification_flow_body = Default::default(); // UpdateVerificationFlowBody
     let token = None; // String | Verification Token  The verification token which completes the verification request. If the token is invalid (e.g. expired) an error will be shown to the end-user.  This parameter is usually set in a link and not used by any direct API call. (optional)

--- a/clients/client/rust/docs/IdentityApi.md
+++ b/clients/client/rust/docs/IdentityApi.md
@@ -35,6 +35,24 @@ Create multiple identities
 
 Creates multiple [identities](https://www.ory.com/docs/kratos/concepts/identity-user-model).  You can also use this endpoint to [import credentials](https://www.ory.com/docs/kratos/manage-identities/import-user-accounts-identities), including passwords, social sign-in settings, and multi-factor authentication methods.  If the patch includes hashed passwords you can import up to 1,000 identities per request.  If the patch includes at least one plaintext password you can import up to 200 identities per request.  Avoid importing large batches with plaintext passwords. They can cause timeouts as the passwords need to be hashed before they are stored.  If at least one identity is imported successfully, the response status is 200 OK. If all imports fail, the response is one of the following 4xx errors: 400 Bad Request: The request payload is invalid or improperly formatted. 409 Conflict: Duplicate identities or conflicting data were detected.  If you get a 504 Gateway Timeout: Reduce the batch size Avoid duplicate identities Pre-hash passwords with BCrypt  If the issue persists, contact support.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::identity_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let patch_identities_body = Some(Default::default()); // PatchIdentitiesBody (optional)
+    match identity_api::batch_patch_identities(&configuration, patch_identities_body).await {
+        Ok(response) => println!("IdentityApi::batch_patch_identities: {:?}", response),
+        Err(error) => eprintln!("Error calling IdentityApi::batch_patch_identities: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -64,6 +82,24 @@ Name | Type | Description  | Required | Notes
 Create an Identity
 
 Create an [identity](https://www.ory.com/docs/kratos/concepts/identity-user-model).  This endpoint can also be used to [import credentials](https://www.ory.com/docs/kratos/manage-identities/import-user-accounts-identities) for instance passwords, social sign in configurations, or multifactor methods.
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::identity_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let create_identity_body = Some(Default::default()); // CreateIdentityBody (optional)
+    match identity_api::create_identity(&configuration, create_identity_body).await {
+        Ok(response) => println!("IdentityApi::create_identity: {:?}", response),
+        Err(error) => eprintln!("Error calling IdentityApi::create_identity: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -95,6 +131,24 @@ Create a Recovery Code
 
 This endpoint creates a recovery code which should be given to the user in order for them to recover (or activate) their account.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::identity_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let create_recovery_code_for_identity_body = Some(Default::default()); // CreateRecoveryCodeForIdentityBody (optional)
+    match identity_api::create_recovery_code_for_identity(&configuration, create_recovery_code_for_identity_body).await {
+        Ok(response) => println!("IdentityApi::create_recovery_code_for_identity: {:?}", response),
+        Err(error) => eprintln!("Error calling IdentityApi::create_recovery_code_for_identity: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -124,6 +178,25 @@ Name | Type | Description  | Required | Notes
 Create a Recovery Link
 
 This endpoint creates a recovery link which should be given to the user in order for them to recover (or activate) their account.
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::identity_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let return_to = None; // String (optional)
+    let create_recovery_link_for_identity_body = Some(Default::default()); // CreateRecoveryLinkForIdentityBody (optional)
+    match identity_api::create_recovery_link_for_identity(&configuration, return_to, create_recovery_link_for_identity_body).await {
+        Ok(response) => println!("IdentityApi::create_recovery_link_for_identity: {:?}", response),
+        Err(error) => eprintln!("Error calling IdentityApi::create_recovery_link_for_identity: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -156,6 +229,24 @@ Create a test OIDC login flow
 
 Creates a dry-run OIDC test login flow pre-scoped to one provider. The returned flow carries a single-submit UI and a CSRF bearer token. No identity is persisted and no session is issued when the flow completes; the captured debug data is returned in the flow's test_context.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::identity_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let create_test_login_flow_body = Default::default(); // CreateTestLoginFlowBody
+    match identity_api::create_test_login_flow(&configuration, create_test_login_flow_body).await {
+        Ok(response) => println!("IdentityApi::create_test_login_flow: {:?}", response),
+        Err(error) => eprintln!("Error calling IdentityApi::create_test_login_flow: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -186,6 +277,24 @@ Delete an Identity
 
 Calling this endpoint irrecoverably and permanently deletes the [identity](https://www.ory.com/docs/kratos/concepts/identity-user-model) given its ID. This action can not be undone. This endpoint returns 204 when the identity was deleted or 404 if the identity was not found.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::identity_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let id = "id_example"; // String | ID is the identity's ID.
+    match identity_api::delete_identity(&configuration, id).await {
+        Ok(_) => println!("IdentityApi::delete_identity"),
+        Err(error) => eprintln!("Error calling IdentityApi::delete_identity: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -215,6 +324,26 @@ Name | Type | Description  | Required | Notes
 Delete a credential for a specific identity
 
 Delete an [identity](https://www.ory.com/docs/kratos/concepts/identity-user-model) credential by its type. You cannot delete passkeys or code auth credentials through this API.
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::identity_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let id = "id_example"; // String | ID is the identity's ID.
+    let r#type = "r#type_example"; // String | Type is the type of credentials to delete. password CredentialsTypePassword oidc CredentialsTypeOIDC totp CredentialsTypeTOTP lookup_secret CredentialsTypeLookup webauthn CredentialsTypeWebAuthn code CredentialsTypeCodeAuth passkey CredentialsTypePasskey profile CredentialsTypeProfile saml CredentialsTypeSAML deviceauthn CredentialsTypeDeviceAuthn identifier_first CredentialsTypeIdentifierFirst link_recovery CredentialsTypeRecoveryLink  CredentialsTypeRecoveryLink is a special credential type linked to the link strategy (recovery flow).  It is not used within the credentials object itself. code_recovery CredentialsTypeRecoveryCode
+    let identifier = None; // String | Identifier is the identifier of the credential to delete. It is required for the `oidc`, `saml`, and `deviceauthn` credential types: for `oidc` and `saml` it selects the provider link to remove, for `deviceauthn` it is the `client_key_id` of the device key to revoke. Find the identifier by calling the `GET /admin/identities/{id}?include_credential={type}` endpoint. (optional)
+    match identity_api::delete_identity_credentials(&configuration, id, r#type, identifier).await {
+        Ok(_) => println!("IdentityApi::delete_identity_credentials"),
+        Err(error) => eprintln!("Error calling IdentityApi::delete_identity_credentials: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -248,6 +377,24 @@ Delete & Invalidate an Identity's Sessions
 
 Calling this endpoint irrecoverably and permanently deletes and invalidates all sessions that belong to the given Identity.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::identity_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let id = "id_example"; // String | ID is the identity's ID.
+    match identity_api::delete_identity_sessions(&configuration, id).await {
+        Ok(_) => println!("IdentityApi::delete_identity_sessions"),
+        Err(error) => eprintln!("Error calling IdentityApi::delete_identity_sessions: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -277,6 +424,24 @@ Name | Type | Description  | Required | Notes
 Deactivate a Session
 
 Calling this endpoint deactivates the specified session. Session data is not deleted.
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::identity_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let id = "id_example"; // String | ID is the session's ID.
+    match identity_api::disable_session(&configuration, id).await {
+        Ok(_) => println!("IdentityApi::disable_session"),
+        Err(error) => eprintln!("Error calling IdentityApi::disable_session: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -308,6 +473,24 @@ Extend a Session
 
 Calling this endpoint extends the given session ID. If `session.earliest_possible_extend` is set it will only extend the session after the specified time has passed.  This endpoint returns per default a 204 No Content response on success. Older Ory Network projects may return a 200 OK response with the session in the body. Returning the session as part of the response will be deprecated in the future and should not be relied upon.  This endpoint ignores consecutive requests to extend the same session and returns a 404 error in those scenarios. This endpoint also returns 404 errors if the session does not exist.  Retrieve the session ID from the `/sessions/whoami` endpoint / `toSession` SDK method.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::identity_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let id = "id_example"; // String | ID is the session's ID.
+    match identity_api::extend_session(&configuration, id).await {
+        Ok(response) => println!("IdentityApi::extend_session: {:?}", response),
+        Err(error) => eprintln!("Error calling IdentityApi::extend_session: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -337,6 +520,25 @@ Name | Type | Description  | Required | Notes
 Get an Identity
 
 Return an [identity](https://www.ory.com/docs/kratos/concepts/identity-user-model) by its ID. You can optionally include credentials (e.g. social sign in connections) in the response by using the `include_credential` query parameter.
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::identity_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let id = "id_example"; // String | ID must be set to the ID of identity you want to get
+    let include_credential = None; // Vec<String> | Include Credentials in Response  Include any credential, for example `password` or `oidc`, in the response. When set to `oidc`, This will return the initial OAuth 2.0 Access Token, OAuth 2.0 Refresh Token, and the OpenID Connect ID Token if available. (optional)
+    match identity_api::get_identity(&configuration, id, include_credential).await {
+        Ok(response) => println!("IdentityApi::get_identity: {:?}", response),
+        Err(error) => eprintln!("Error calling IdentityApi::get_identity: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -369,6 +571,25 @@ Get an Identity by its External ID
 
 Return an [identity](https://www.ory.com/docs/kratos/concepts/identity-user-model) by its external ID. You can optionally include credentials (e.g. social sign in connections) in the response by using the `include_credential` query parameter.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::identity_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let external_id = "external_id_example"; // String | ExternalID must be set to the ID of identity you want to get
+    let include_credential = None; // Vec<String> | Include Credentials in Response  Include any credential, for example `password` or `oidc`, in the response. When set to `oidc`, This will return the initial OAuth 2.0 Access Token, OAuth 2.0 Refresh Token, and the OpenID Connect ID Token if available. (optional)
+    match identity_api::get_identity_by_external_id(&configuration, external_id, include_credential).await {
+        Ok(response) => println!("IdentityApi::get_identity_by_external_id: {:?}", response),
+        Err(error) => eprintln!("Error calling IdentityApi::get_identity_by_external_id: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -400,6 +621,24 @@ Get Identity JSON Schema
 
 Return a specific identity schema.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::identity_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let id = "id_example"; // String | ID must be set to the ID of schema you want to get
+    match identity_api::get_identity_schema(&configuration, id).await {
+        Ok(response) => println!("IdentityApi::get_identity_schema: {:?}", response),
+        Err(error) => eprintln!("Error calling IdentityApi::get_identity_schema: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -429,6 +668,25 @@ No authorization required
 Get Session
 
 This endpoint is useful for:  Getting a session object with all specified expandables that exist in an administrative context.
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::identity_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let id = "id_example"; // String | ID is the session's ID.
+    let expand = None; // Vec<String> | ExpandOptions is a query parameter encoded list of all properties that must be expanded in the Session. Example - ?expand=Identity&expand=Devices If no value is provided, the expandable properties are skipped. (optional)
+    match identity_api::get_session(&configuration, id, expand).await {
+        Ok(response) => println!("IdentityApi::get_session: {:?}", response),
+        Err(error) => eprintln!("Error calling IdentityApi::get_session: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -460,6 +718,33 @@ Name | Type | Description  | Required | Notes
 List Identities
 
 Lists all [identities](https://www.ory.com/docs/kratos/concepts/identity-user-model) in the system. Note: filters cannot be combined.
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::identity_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let per_page = None; // i64 | Deprecated Items per Page  DEPRECATED: Please use `page_token` instead. This parameter will be removed in the future.  This is the number of items per page. (optional)
+    let page = None; // i64 | Deprecated Pagination Page  DEPRECATED: Please use `page_token` instead. This parameter will be removed in the future.  This value is currently an integer, but it is not sequential. The value is not the page number, but a reference. The next page can be any number and some numbers might return an empty list.  For example, page 2 might not follow after page 1. And even if page 3 and 5 exist, but page 4 might not exist. The first page can be retrieved by omitting this parameter. Following page pointers will be returned in the `Link` header. (optional)
+    let page_size = None; // i64 | Page Size  This is the number of items per page to return. For details on pagination please head over to the [pagination documentation](https://www.ory.com/docs/ecosystem/api-design#pagination). (optional)
+    let page_token = None; // String | Next Page Token  The next page token. For details on pagination please head over to the [pagination documentation](https://www.ory.com/docs/ecosystem/api-design#pagination). (optional)
+    let consistency = None; // String | Read Consistency Level (preview)  The read consistency level determines the consistency guarantee for reads:  strong (slow): The read is guaranteed to return the most recent data committed at the start of the read. eventual (very fast): The result will return data that is about 4.8 seconds old.  The default consistency guarantee can be changed in the Ory Network Console or using the Ory CLI with `ory patch project --replace '/previews/default_read_consistency_level=\"strong\"'`.  Setting the default consistency level to `eventual` may cause regressions in the future as we add consistency controls to more APIs. Currently, the following APIs will be affected by this setting:  `GET /admin/identities`  This feature is in preview and only available in Ory Network.  ConsistencyLevelUnset  ConsistencyLevelUnset is the unset / default consistency level. strong ConsistencyLevelStrong  ConsistencyLevelStrong is the strong consistency level. eventual ConsistencyLevelEventual  ConsistencyLevelEventual is the eventual consistency level using follower read timestamps. (optional)
+    let ids = None; // Vec<String> | Retrieve multiple identities by their IDs.  This parameter has the following limitations:  Duplicate or non-existent IDs are ignored. The order of returned IDs may be different from the request. This filter does not support pagination. You must implement your own pagination as the maximum number of items returned by this endpoint may not exceed a certain threshold (currently 500). (optional)
+    let credentials_identifier = None; // String | CredentialsIdentifier is the identifier (username, email) of the credentials to look up using exact match. Only one of CredentialsIdentifier and CredentialsIdentifierSimilar can be used. (optional)
+    let preview_credentials_identifier_similar = None; // String | This is an EXPERIMENTAL parameter that WILL CHANGE. Do NOT rely on consistent, deterministic behavior. THIS PARAMETER WILL BE REMOVED IN AN UPCOMING RELEASE WITHOUT ANY MIGRATION PATH.  CredentialsIdentifierSimilar is the (partial) identifier (username, email) of the credentials to look up using similarity search. Only one of CredentialsIdentifier and CredentialsIdentifierSimilar can be used. (optional)
+    let include_credential = None; // Vec<String> | Include Credentials in Response  Include any credential, for example `password` or `oidc`, in the response. When set to `oidc`, This will return the initial OAuth 2.0 Access Token, OAuth 2.0 Refresh Token, and the OpenID Connect ID Token if available. (optional)
+    let organization_id = None; // String | List identities that belong to a specific organization. (optional)
+    match identity_api::list_identities(&configuration, per_page, page, page_size, page_token, consistency, ids, credentials_identifier, preview_credentials_identifier_similar, include_credential, organization_id).await {
+        Ok(response) => println!("IdentityApi::list_identities: {:?}", response),
+        Err(error) => eprintln!("Error calling IdentityApi::list_identities: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -500,6 +785,27 @@ Get all Identity Schemas
 
 Returns a list of all identity schemas currently in use.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::identity_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let per_page = None; // i64 | Deprecated Items per Page  DEPRECATED: Please use `page_token` instead. This parameter will be removed in the future.  This is the number of items per page. (optional)
+    let page = None; // i64 | Deprecated Pagination Page  DEPRECATED: Please use `page_token` instead. This parameter will be removed in the future.  This value is currently an integer, but it is not sequential. The value is not the page number, but a reference. The next page can be any number and some numbers might return an empty list.  For example, page 2 might not follow after page 1. And even if page 3 and 5 exist, but page 4 might not exist. The first page can be retrieved by omitting this parameter. Following page pointers will be returned in the `Link` header. (optional)
+    let page_size = None; // i64 | Page Size  This is the number of items per page to return. For details on pagination please head over to the [pagination documentation](https://www.ory.com/docs/ecosystem/api-design#pagination). (optional)
+    let page_token = None; // String | Next Page Token  The next page token. For details on pagination please head over to the [pagination documentation](https://www.ory.com/docs/ecosystem/api-design#pagination). (optional)
+    match identity_api::list_identity_schemas(&configuration, per_page, page, page_size, page_token).await {
+        Ok(response) => println!("IdentityApi::list_identity_schemas: {:?}", response),
+        Err(error) => eprintln!("Error calling IdentityApi::list_identity_schemas: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -532,6 +838,29 @@ No authorization required
 List an Identity's Sessions
 
 This endpoint returns all sessions that belong to the given Identity.
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::identity_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let id = "id_example"; // String | ID is the identity's ID.
+    let per_page = None; // i64 | Deprecated Items per Page  DEPRECATED: Please use `page_token` instead. This parameter will be removed in the future.  This is the number of items per page. (optional)
+    let page = None; // i64 | Deprecated Pagination Page  DEPRECATED: Please use `page_token` instead. This parameter will be removed in the future.  This value is currently an integer, but it is not sequential. The value is not the page number, but a reference. The next page can be any number and some numbers might return an empty list.  For example, page 2 might not follow after page 1. And even if page 3 and 5 exist, but page 4 might not exist. The first page can be retrieved by omitting this parameter. Following page pointers will be returned in the `Link` header. (optional)
+    let page_size = None; // i64 | Page Size  This is the number of items per page to return. For details on pagination please head over to the [pagination documentation](https://www.ory.com/docs/ecosystem/api-design#pagination). (optional)
+    let page_token = None; // String | Next Page Token  The next page token. For details on pagination please head over to the [pagination documentation](https://www.ory.com/docs/ecosystem/api-design#pagination). (optional)
+    let active = None; // bool | Active is a boolean flag that filters out sessions based on the state. If no value is provided, all sessions are returned. (optional)
+    match identity_api::list_identity_sessions(&configuration, id, per_page, page, page_size, page_token, active).await {
+        Ok(response) => println!("IdentityApi::list_identity_sessions: {:?}", response),
+        Err(error) => eprintln!("Error calling IdentityApi::list_identity_sessions: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -568,6 +897,27 @@ List All Sessions
 
 Listing all sessions that exist.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::identity_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let page_size = None; // i64 | Items per Page  This is the number of items per page to return. For details on pagination please head over to the [pagination documentation](https://www.ory.com/docs/ecosystem/api-design#pagination). (optional)
+    let page_token = None; // String | Next Page Token  The next page token. For details on pagination please head over to the [pagination documentation](https://www.ory.com/docs/ecosystem/api-design#pagination). (optional)
+    let active = None; // bool | Active is a boolean flag that filters out sessions based on the state. If no value is provided, all sessions are returned. (optional)
+    let expand = None; // Vec<String> | ExpandOptions is a query parameter encoded list of all properties that must be expanded in the Session. If no value is provided, the expandable properties are skipped. (optional)
+    match identity_api::list_sessions(&configuration, page_size, page_token, active, expand).await {
+        Ok(response) => println!("IdentityApi::list_sessions: {:?}", response),
+        Err(error) => eprintln!("Error calling IdentityApi::list_sessions: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -601,6 +951,24 @@ Manage sessions in bulk
 
 Disable or delete sessions for a list of identities or a list of sessions in a single call. The `action` field selects the operation:  `disable` — deactivate matching sessions (sets `active = false`, preserves audit data). `delete` — permanently delete matching sessions.  Exactly one of `identities` or `sessions` must be provided. To scope the operation to every session in the network, pass `identities: [\"*\"]`; the wildcard is not accepted in the `sessions` field. Up to 500 explicit IDs are accepted per call.  All requests return `200 OK` with `{processed, more}`. `processed` reports how many rows the call affected; for `disable` it counts only sessions that were active before the call. `more` is `true` only when a wildcard request reached the per-call batch limit and additional rows may remain; callers drain the network by re-issuing the same request while `more` is `true`. Explicit-IDs requests always return `more: false`.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::identity_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let manage_sessions_body = Default::default(); // ManageSessionsBody
+    match identity_api::manage_sessions(&configuration, manage_sessions_body).await {
+        Ok(response) => println!("IdentityApi::manage_sessions: {:?}", response),
+        Err(error) => eprintln!("Error calling IdentityApi::manage_sessions: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -630,6 +998,25 @@ Name | Type | Description  | Required | Notes
 Patch an Identity
 
 Partially updates an [identity's](https://www.ory.com/docs/kratos/concepts/identity-user-model) field using [JSON Patch](https://jsonpatch.com/). The fields `id`, `stateChangedAt` and `credentials` can not be updated using this method.
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::identity_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let id = "id_example"; // String | ID must be set to the ID of identity you want to update
+    let json_patch = Some(Default::default()); // Vec<models::JsonPatch> (optional)
+    match identity_api::patch_identity(&configuration, id, json_patch).await {
+        Ok(response) => println!("IdentityApi::patch_identity: {:?}", response),
+        Err(error) => eprintln!("Error calling IdentityApi::patch_identity: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -661,6 +1048,25 @@ Name | Type | Description  | Required | Notes
 Update an Identity
 
 This endpoint updates an [identity](https://www.ory.com/docs/kratos/concepts/identity-user-model). The full identity payload (except credentials) is expected.  It is possible to update the identity's credentials as well. Using this operation, credentials will not be overwritten but instead added to the list. For example, if a user has a social sign in connection set up, updating the credentials will keep the social sign in connection and add the new credentials to the list. This prevents accidentally overwriting credentials and locking out users. A complete view of all credential types is here:  `password`: The existing password credential will be completely replaced with the new configuration. You can provide either a hashed password, a plaintext password (which will be hashed), or enable the password migration hook. `oidc`, `saml`: The existing OIDC and SAML credentials will be kept and the new credentials will be added to the list. `totp`: The existing TOTP credentials will be replaced with the new configuration. `lookup_secret`: The existing Lookup Secret codes will be kept and the new codes will be added to the list. `webauthn`, `passkey`: The existing credentials are preserved, new credentials are added, and credentials with matching IDs are updated with new values. If a new `user_handle` is provided, it's added to the identity's identifiers list while preserving previous user handles. `code`: To import code credentials, configure your identity schema to use one of the identity traits as an identifier source (`{\"ory.sh/kratos\":{\"code\":{\"identifier\":true\", \"via\":\"email\"}}}`).
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::identity_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let id = "id_example"; // String | ID must be set to the ID of identity you want to update
+    let update_identity_body = Some(Default::default()); // UpdateIdentityBody (optional)
+    match identity_api::update_identity(&configuration, id, update_identity_body).await {
+        Ok(response) => println!("IdentityApi::update_identity: {:?}", response),
+        Err(error) => eprintln!("Error calling IdentityApi::update_identity: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 

--- a/clients/client/rust/docs/IdentityApi.md
+++ b/clients/client/rust/docs/IdentityApi.md
@@ -630,7 +630,6 @@ use ory_client::apis::identity_api;
 #[tokio::main]
 async fn main() {
     let mut configuration = Configuration::new();
-    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
     let id = "id_example"; // String | ID must be set to the ID of schema you want to get
     match identity_api::get_identity_schema(&configuration, id).await {
         Ok(response) => println!("IdentityApi::get_identity_schema: {:?}", response),
@@ -794,7 +793,6 @@ use ory_client::apis::identity_api;
 #[tokio::main]
 async fn main() {
     let mut configuration = Configuration::new();
-    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
     let per_page = None; // i64 | Deprecated Items per Page  DEPRECATED: Please use `page_token` instead. This parameter will be removed in the future.  This is the number of items per page. (optional)
     let page = None; // i64 | Deprecated Pagination Page  DEPRECATED: Please use `page_token` instead. This parameter will be removed in the future.  This value is currently an integer, but it is not sequential. The value is not the page number, but a reference. The next page can be any number and some numbers might return an empty list.  For example, page 2 might not follow after page 1. And even if page 3 and 5 exist, but page 4 might not exist. The first page can be retrieved by omitting this parameter. Following page pointers will be returned in the `Link` header. (optional)
     let page_size = None; // i64 | Page Size  This is the number of items per page to return. For details on pagination please head over to the [pagination documentation](https://www.ory.com/docs/ecosystem/api-design#pagination). (optional)

--- a/clients/client/rust/docs/JwkApi.md
+++ b/clients/client/rust/docs/JwkApi.md
@@ -21,6 +21,25 @@ Create JSON Web Key
 
 This endpoint is capable of generating JSON Web Key Sets for you. There are different strategies available, such as symmetric cryptographic keys (HS256, HS512) and asymmetric cryptographic keys (RS256, ECDSA). If the specified JSON Web Key Set does not exist, it will be created.  If the set already exists, the newly generated key is added to it and all existing keys are kept. This allows you to rotate keys: tokens signed with an older key in the set remain verifiable. Exception: when Ory Hydra is configured to use a Hardware Security Module (HSM), generating a key replaces the set, which then contains only the new key. To replace a set and all of its keys instead, use the `setJsonWebKeySet` operation (`PUT /admin/keys/{set}`).  A JSON Web Key (JWK) is a JavaScript Object Notation (JSON) data structure that represents a cryptographic key. A JWK Set is a JSON data structure that represents a set of JWKs. A JSON Web Key is identified by its set and key id. ORY Hydra uses this functionality to store cryptographic keys used for TLS and JSON Web Tokens (such as OpenID Connect ID tokens), and allows storing user-defined keys as well.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::jwk_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let set = "set_example"; // String | The JSON Web Key Set ID
+    let create_json_web_key_set = Default::default(); // CreateJsonWebKeySet
+    match jwk_api::create_json_web_key_set(&configuration, set, create_json_web_key_set).await {
+        Ok(response) => println!("JwkApi::create_json_web_key_set: {:?}", response),
+        Err(error) => eprintln!("Error calling JwkApi::create_json_web_key_set: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -51,6 +70,25 @@ Name | Type | Description  | Required | Notes
 Delete JSON Web Key
 
 Use this endpoint to delete a single JSON Web Key.  A JSON Web Key (JWK) is a JavaScript Object Notation (JSON) data structure that represents a cryptographic key. A JWK Set is a JSON data structure that represents a set of JWKs. A JSON Web Key is identified by its set and key id. ORY Hydra uses this functionality to store cryptographic keys used for TLS and JSON Web Tokens (such as OpenID Connect ID tokens), and allows storing user-defined keys as well.
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::jwk_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let set = "set_example"; // String | The JSON Web Key Set
+    let kid = "kid_example"; // String | The JSON Web Key ID (kid)
+    match jwk_api::delete_json_web_key(&configuration, set, kid).await {
+        Ok(_) => println!("JwkApi::delete_json_web_key"),
+        Err(error) => eprintln!("Error calling JwkApi::delete_json_web_key: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -83,6 +121,24 @@ Delete JSON Web Key Set
 
 Use this endpoint to delete a complete JSON Web Key Set and all the keys in that set.  A JSON Web Key (JWK) is a JavaScript Object Notation (JSON) data structure that represents a cryptographic key. A JWK Set is a JSON data structure that represents a set of JWKs. A JSON Web Key is identified by its set and key id. ORY Hydra uses this functionality to store cryptographic keys used for TLS and JSON Web Tokens (such as OpenID Connect ID tokens), and allows storing user-defined keys as well.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::jwk_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let set = "set_example"; // String | The JSON Web Key Set
+    match jwk_api::delete_json_web_key_set(&configuration, set).await {
+        Ok(_) => println!("JwkApi::delete_json_web_key_set"),
+        Err(error) => eprintln!("Error calling JwkApi::delete_json_web_key_set: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -112,6 +168,25 @@ Name | Type | Description  | Required | Notes
 Get JSON Web Key
 
 This endpoint returns a singular JSON Web Key contained in a set. It is identified by the set and the specific key ID (kid).
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::jwk_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let set = "set_example"; // String | JSON Web Key Set ID
+    let kid = "kid_example"; // String | JSON Web Key ID
+    match jwk_api::get_json_web_key(&configuration, set, kid).await {
+        Ok(response) => println!("JwkApi::get_json_web_key: {:?}", response),
+        Err(error) => eprintln!("Error calling JwkApi::get_json_web_key: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -144,6 +219,24 @@ Retrieve a JSON Web Key Set
 
 This endpoint can be used to retrieve JWK Sets stored in ORY Hydra.  A JSON Web Key (JWK) is a JavaScript Object Notation (JSON) data structure that represents a cryptographic key. A JWK Set is a JSON data structure that represents a set of JWKs. A JSON Web Key is identified by its set and key id. ORY Hydra uses this functionality to store cryptographic keys used for TLS and JSON Web Tokens (such as OpenID Connect ID tokens), and allows storing user-defined keys as well.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::jwk_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let set = "set_example"; // String | JSON Web Key Set ID
+    match jwk_api::get_json_web_key_set(&configuration, set).await {
+        Ok(response) => println!("JwkApi::get_json_web_key_set: {:?}", response),
+        Err(error) => eprintln!("Error calling JwkApi::get_json_web_key_set: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -173,6 +266,26 @@ Name | Type | Description  | Required | Notes
 Set JSON Web Key
 
 Use this method if you do not want to let Hydra generate the JWKs for you, but instead save your own.  Warning: the key is created or updated under the `kid` given in the request body. The `{kid}` path parameter exists for historical reasons only: it is ignored and not validated against the body.  A JSON Web Key (JWK) is a JavaScript Object Notation (JSON) data structure that represents a cryptographic key. A JWK Set is a JSON data structure that represents a set of JWKs. A JSON Web Key is identified by its set and key id. ORY Hydra uses this functionality to store cryptographic keys used for TLS and JSON Web Tokens (such as OpenID Connect ID tokens), and allows storing user-defined keys as well.
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::jwk_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let set = "set_example"; // String | The JSON Web Key Set ID
+    let kid = "kid_example"; // String | JSON Web Key ID
+    let json_web_key = Some(Default::default()); // JsonWebKey (optional)
+    match jwk_api::set_json_web_key(&configuration, set, kid, json_web_key).await {
+        Ok(response) => println!("JwkApi::set_json_web_key: {:?}", response),
+        Err(error) => eprintln!("Error calling JwkApi::set_json_web_key: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -205,6 +318,25 @@ Name | Type | Description  | Required | Notes
 Update a JSON Web Key Set
 
 Use this method if you do not want to let Hydra generate the JWKs for you, but instead save your own.  This operation replaces the entire JSON Web Key Set: keys that exist in the set but are not part of the request body are deleted. To add a newly generated key to the set while keeping the existing keys, use the `createJsonWebKeySet` operation (`POST /admin/keys/{set}`).  A JSON Web Key (JWK) is a JavaScript Object Notation (JSON) data structure that represents a cryptographic key. A JWK Set is a JSON data structure that represents a set of JWKs. A JSON Web Key is identified by its set and key id. ORY Hydra uses this functionality to store cryptographic keys used for TLS and JSON Web Tokens (such as OpenID Connect ID tokens), and allows storing user-defined keys as well.
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::jwk_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let set = "set_example"; // String | The JSON Web Key Set ID
+    let json_web_key_set = Some(Default::default()); // JsonWebKeySet (optional)
+    match jwk_api::set_json_web_key_set(&configuration, set, json_web_key_set).await {
+        Ok(response) => println!("JwkApi::set_json_web_key_set: {:?}", response),
+        Err(error) => eprintln!("Error calling JwkApi::set_json_web_key_set: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 

--- a/clients/client/rust/docs/MetadataApi.md
+++ b/clients/client/rust/docs/MetadataApi.md
@@ -15,6 +15,23 @@ Return Running Software Version.
 
 This endpoint returns the version of Ory Kratos.  If the service supports TLS Edge Termination, this endpoint does not require the `X-Forwarded-Proto` header to be set.  Be aware that if you are running multiple nodes of this service, the version will never refer to the cluster state, only to a single instance.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::metadata_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    match metadata_api::get_version(&configuration).await {
+        Ok(response) => println!("MetadataApi::get_version: {:?}", response),
+        Err(error) => eprintln!("Error calling MetadataApi::get_version: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 This endpoint does not need any parameter.

--- a/clients/client/rust/docs/OAuth2Api.md
+++ b/clients/client/rust/docs/OAuth2Api.md
@@ -944,7 +944,6 @@ use ory_client::apis::o_auth2_api;
 #[tokio::main]
 async fn main() {
     let mut configuration = Configuration::new();
-    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
     match o_auth2_api::o_auth2_authorize(&configuration).await {
         Ok(response) => println!("OAuth2Api::o_auth2_authorize: {:?}", response),
         Err(error) => eprintln!("Error calling OAuth2Api::o_auth2_authorize: {:?}", error),
@@ -988,7 +987,6 @@ use ory_client::apis::o_auth2_api;
 #[tokio::main]
 async fn main() {
     let mut configuration = Configuration::new();
-    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
     match o_auth2_api::o_auth2_device_flow(&configuration).await {
         Ok(response) => println!("OAuth2Api::o_auth2_device_flow: {:?}", response),
         Err(error) => eprintln!("Error calling OAuth2Api::o_auth2_device_flow: {:?}", error),
@@ -1138,7 +1136,6 @@ use ory_client::apis::o_auth2_api;
 #[tokio::main]
 async fn main() {
     let mut configuration = Configuration::new();
-    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
     match o_auth2_api::perform_o_auth2_device_verification_flow(&configuration).await {
         Ok(response) => println!("OAuth2Api::perform_o_auth2_device_verification_flow: {:?}", response),
         Err(error) => eprintln!("Error calling OAuth2Api::perform_o_auth2_device_verification_flow: {:?}", error),

--- a/clients/client/rust/docs/OAuth2Api.md
+++ b/clients/client/rust/docs/OAuth2Api.md
@@ -47,6 +47,25 @@ Accept OAuth 2.0 Consent Request
 
 When an authorization code, hybrid, or implicit OAuth 2.0 Flow is initiated, Ory asks the login provider to authenticate the subject and then tell Ory now about it. If the subject authenticated, he/she must now be asked if the OAuth 2.0 Client which initiated the flow should be allowed to access the resources on the subject's behalf.  The consent challenge is appended to the consent provider's URL to which the subject's user-agent (browser) is redirected to. The consent provider uses that challenge to fetch information on the OAuth2 request and then tells Ory if the subject accepted or rejected the request.  This endpoint tells Ory that the subject has authorized the OAuth 2.0 client to access resources on his/her behalf. The consent provider includes additional information, such as session data for access and ID tokens, and if the consent request should be used as basis for future requests.  The response contains a redirect URL which the consent provider should redirect the user-agent to.  The default consent provider is available via the Ory Managed Account Experience. To customize the consent provider, please head over to the OAuth 2.0 documentation.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::o_auth2_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let consent_challenge = "consent_challenge_example"; // String | OAuth 2.0 Consent Request Challenge
+    let accept_o_auth2_consent_request = Some(Default::default()); // AcceptOAuth2ConsentRequest (optional)
+    match o_auth2_api::accept_o_auth2_consent_request(&configuration, consent_challenge, accept_o_auth2_consent_request).await {
+        Ok(response) => println!("OAuth2Api::accept_o_auth2_consent_request: {:?}", response),
+        Err(error) => eprintln!("Error calling OAuth2Api::accept_o_auth2_consent_request: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -77,6 +96,25 @@ Name | Type | Description  | Required | Notes
 Accept OAuth 2.0 Login Request
 
 When an authorization code, hybrid, or implicit OAuth 2.0 Flow is initiated, Ory asks the login provider to authenticate the subject and then tell the Ory OAuth2 Service about it.  The authentication challenge is appended to the login provider URL to which the subject's user-agent (browser) is redirected to. The login provider uses that challenge to fetch information on the OAuth2 request and then accept or reject the requested authentication process.  This endpoint tells Ory that the subject has successfully authenticated and includes additional information such as the subject's ID and if Ory should remember the subject's subject agent for future authentication attempts by setting a cookie.  The response contains a redirect URL which the login provider should redirect the user-agent to.
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::o_auth2_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let login_challenge = "login_challenge_example"; // String | OAuth 2.0 Login Request Challenge
+    let accept_o_auth2_login_request = Some(Default::default()); // AcceptOAuth2LoginRequest (optional)
+    match o_auth2_api::accept_o_auth2_login_request(&configuration, login_challenge, accept_o_auth2_login_request).await {
+        Ok(response) => println!("OAuth2Api::accept_o_auth2_login_request: {:?}", response),
+        Err(error) => eprintln!("Error calling OAuth2Api::accept_o_auth2_login_request: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -109,6 +147,24 @@ Accept OAuth 2.0 Session Logout Request
 
 When a user or an application requests Ory OAuth 2.0 to remove the session state of a subject, this endpoint is used to confirm that logout request.  The response contains a redirect URL which the consent provider should redirect the user-agent to.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::o_auth2_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let logout_challenge = "logout_challenge_example"; // String | OAuth 2.0 Logout Request Challenge
+    match o_auth2_api::accept_o_auth2_logout_request(&configuration, logout_challenge).await {
+        Ok(response) => println!("OAuth2Api::accept_o_auth2_logout_request: {:?}", response),
+        Err(error) => eprintln!("Error calling OAuth2Api::accept_o_auth2_logout_request: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -138,6 +194,25 @@ Name | Type | Description  | Required | Notes
 Accepts a device grant user_code request
 
 Accepts a device grant user_code request
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::o_auth2_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let device_challenge = "device_challenge_example"; // String
+    let accept_device_user_code_request = Some(Default::default()); // AcceptDeviceUserCodeRequest (optional)
+    match o_auth2_api::accept_user_code_request(&configuration, device_challenge, accept_device_user_code_request).await {
+        Ok(response) => println!("OAuth2Api::accept_user_code_request: {:?}", response),
+        Err(error) => eprintln!("Error calling OAuth2Api::accept_user_code_request: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -170,6 +245,24 @@ Create OAuth 2.0 Client
 
 Create a new OAuth 2.0 client. If you pass `client_secret` the secret is used, otherwise a random secret is generated. The secret is echoed in the response. It is not possible to retrieve it later on.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::o_auth2_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let o_auth2_client = Default::default(); // OAuth2Client | OAuth 2.0 Client Request Body
+    match o_auth2_api::create_o_auth2_client(&configuration, o_auth2_client).await {
+        Ok(response) => println!("OAuth2Api::create_o_auth2_client: {:?}", response),
+        Err(error) => eprintln!("Error calling OAuth2Api::create_o_auth2_client: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -199,6 +292,24 @@ Name | Type | Description  | Required | Notes
 Delete OAuth 2.0 Client
 
 Delete an existing OAuth 2.0 Client by its ID.  OAuth 2.0 clients are used to perform OAuth 2.0 and OpenID Connect flows. Usually, OAuth 2.0 clients are generated for applications which want to consume your OAuth 2.0 or OpenID Connect capabilities.  Make sure that this endpoint is well protected and only callable by first-party components.
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::o_auth2_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let id = "id_example"; // String | The id of the OAuth 2.0 Client.
+    match o_auth2_api::delete_o_auth2_client(&configuration, id).await {
+        Ok(_) => println!("OAuth2Api::delete_o_auth2_client"),
+        Err(error) => eprintln!("Error calling OAuth2Api::delete_o_auth2_client: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -230,6 +341,24 @@ Delete OAuth 2.0 Access Tokens from specific OAuth 2.0 Client
 
 This endpoint deletes OAuth2 access tokens issued to an OAuth 2.0 Client from the database.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::o_auth2_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let client_id = "client_id_example"; // String | OAuth 2.0 Client ID
+    match o_auth2_api::delete_o_auth2_token(&configuration, client_id).await {
+        Ok(_) => println!("OAuth2Api::delete_o_auth2_token"),
+        Err(error) => eprintln!("Error calling OAuth2Api::delete_o_auth2_token: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -259,6 +388,24 @@ Name | Type | Description  | Required | Notes
 Delete Rotated OAuth 2.0 Client Secrets
 
 Removes all rotated secrets from an OAuth 2.0 client. This should be called after all services have been updated to use the new secret and the old secrets are no longer needed.
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::o_auth2_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let id = "id_example"; // String | OAuth 2.0 Client ID
+    match o_auth2_api::delete_rotated_o_auth2_client_secrets(&configuration, id).await {
+        Ok(response) => println!("OAuth2Api::delete_rotated_o_auth2_client_secrets: {:?}", response),
+        Err(error) => eprintln!("Error calling OAuth2Api::delete_rotated_o_auth2_client_secrets: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -290,6 +437,24 @@ Delete Trusted OAuth2 JWT Bearer Grant Type Issuer
 
 Use this endpoint to delete trusted JWT Bearer Grant Type Issuer. The ID is the one returned when you created the trust relationship.  Once deleted, the associated issuer will no longer be able to perform the JSON Web Token (JWT) Profile for OAuth 2.0 Client Authentication and Authorization Grant.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::o_auth2_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let id = "id_example"; // String | The id of the desired grant
+    match o_auth2_api::delete_trusted_o_auth2_jwt_grant_issuer(&configuration, id).await {
+        Ok(_) => println!("OAuth2Api::delete_trusted_o_auth2_jwt_grant_issuer"),
+        Err(error) => eprintln!("Error calling OAuth2Api::delete_trusted_o_auth2_jwt_grant_issuer: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -319,6 +484,24 @@ Name | Type | Description  | Required | Notes
 Get an OAuth 2.0 Client
 
 Get an OAuth 2.0 client by its ID. This endpoint never returns the client secret.  OAuth 2.0 clients are used to perform OAuth 2.0 and OpenID Connect flows. Usually, OAuth 2.0 clients are generated for applications which want to consume your OAuth 2.0 or OpenID Connect capabilities.
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::o_auth2_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let id = "id_example"; // String | The id of the OAuth 2.0 Client.
+    match o_auth2_api::get_o_auth2_client(&configuration, id).await {
+        Ok(response) => println!("OAuth2Api::get_o_auth2_client: {:?}", response),
+        Err(error) => eprintln!("Error calling OAuth2Api::get_o_auth2_client: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -350,6 +533,24 @@ Get OAuth 2.0 Consent Request
 
 When an authorization code, hybrid, or implicit OAuth 2.0 Flow is initiated, Ory asks the login provider to authenticate the subject and then tell Ory now about it. If the subject authenticated, he/she must now be asked if the OAuth 2.0 Client which initiated the flow should be allowed to access the resources on the subject's behalf.  The consent challenge is appended to the consent provider's URL to which the subject's user-agent (browser) is redirected to. The consent provider uses that challenge to fetch information on the OAuth2 request and then tells Ory if the subject accepted or rejected the request.  The default consent provider is available via the Ory Managed Account Experience. To customize the consent provider, please head over to the OAuth 2.0 documentation.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::o_auth2_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let consent_challenge = "consent_challenge_example"; // String | OAuth 2.0 Consent Request Challenge
+    match o_auth2_api::get_o_auth2_consent_request(&configuration, consent_challenge).await {
+        Ok(response) => println!("OAuth2Api::get_o_auth2_consent_request: {:?}", response),
+        Err(error) => eprintln!("Error calling OAuth2Api::get_o_auth2_consent_request: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -379,6 +580,24 @@ Name | Type | Description  | Required | Notes
 Get OAuth 2.0 Login Request
 
 When an authorization code, hybrid, or implicit OAuth 2.0 Flow is initiated, Ory asks the login provider to authenticate the subject and then tell the Ory OAuth2 Service about it.  Per default, the login provider is Ory itself. You may use a different login provider which needs to be a web-app you write and host, and it must be able to authenticate (\"show the subject a login screen\") a subject (in OAuth2 the proper name for subject is \"resource owner\").  The authentication challenge is appended to the login provider URL to which the subject's user-agent (browser) is redirected to. The login provider uses that challenge to fetch information on the OAuth2 request and then accept or reject the requested authentication process.
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::o_auth2_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let login_challenge = "login_challenge_example"; // String | OAuth 2.0 Login Request Challenge
+    match o_auth2_api::get_o_auth2_login_request(&configuration, login_challenge).await {
+        Ok(response) => println!("OAuth2Api::get_o_auth2_login_request: {:?}", response),
+        Err(error) => eprintln!("Error calling OAuth2Api::get_o_auth2_login_request: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -410,6 +629,24 @@ Get OAuth 2.0 Session Logout Request
 
 Use this endpoint to fetch an Ory OAuth 2.0 logout request.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::o_auth2_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let logout_challenge = "logout_challenge_example"; // String
+    match o_auth2_api::get_o_auth2_logout_request(&configuration, logout_challenge).await {
+        Ok(response) => println!("OAuth2Api::get_o_auth2_logout_request: {:?}", response),
+        Err(error) => eprintln!("Error calling OAuth2Api::get_o_auth2_logout_request: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -439,6 +676,24 @@ Name | Type | Description  | Required | Notes
 Get Trusted OAuth2 JWT Bearer Grant Type Issuer
 
 Use this endpoint to get a trusted JWT Bearer Grant Type Issuer. The ID is the one returned when you created the trust relationship.
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::o_auth2_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let id = "id_example"; // String | The id of the desired grant
+    match o_auth2_api::get_trusted_o_auth2_jwt_grant_issuer(&configuration, id).await {
+        Ok(response) => println!("OAuth2Api::get_trusted_o_auth2_jwt_grant_issuer: {:?}", response),
+        Err(error) => eprintln!("Error calling OAuth2Api::get_trusted_o_auth2_jwt_grant_issuer: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -470,6 +725,25 @@ Introspect OAuth2 Access and Refresh Tokens
 
 The introspection endpoint allows to check if a token (both refresh and access) is active or not. An active token is neither expired nor revoked. If a token is active, additional information on the token will be included. You can set additional data for a token by setting `session.access_token` during the consent flow.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::o_auth2_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let token = "token_example"; // String | The string value of the token. For access tokens, this is the \\\"access_token\\\" value returned from the token endpoint defined in OAuth 2.0. For refresh tokens, this is the \\\"refresh_token\\\" value returned.
+    let scope = None; // String | An optional, space separated list of required scopes. If the access token was not granted one of the scopes, the result of active will be false. (optional)
+    match o_auth2_api::introspect_o_auth2_token(&configuration, token, scope).await {
+        Ok(response) => println!("OAuth2Api::introspect_o_auth2_token: {:?}", response),
+        Err(error) => eprintln!("Error calling OAuth2Api::introspect_o_auth2_token: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -500,6 +774,27 @@ Name | Type | Description  | Required | Notes
 List OAuth 2.0 Clients
 
 This endpoint lists all clients in the database, and never returns client secrets. As a default it lists the first 100 clients.
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::o_auth2_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let page_size = None; // i64 | Items per Page  This is the number of items per page to return. For details on pagination please head over to the [pagination documentation](https://www.ory.com/docs/ecosystem/api-design#pagination). (optional)
+    let page_token = None; // String | Next Page Token  The next page token. For details on pagination please head over to the [pagination documentation](https://www.ory.com/docs/ecosystem/api-design#pagination). (optional)
+    let client_name = None; // String | The name of the clients to filter by. (optional)
+    let owner = None; // String | The owner of the clients to filter by. (optional)
+    match o_auth2_api::list_o_auth2_clients(&configuration, page_size, page_token, client_name, owner).await {
+        Ok(response) => println!("OAuth2Api::list_o_auth2_clients: {:?}", response),
+        Err(error) => eprintln!("Error calling OAuth2Api::list_o_auth2_clients: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -534,6 +829,27 @@ List OAuth 2.0 Consent Sessions of a Subject
 
 This endpoint lists all subject's granted consent sessions, including client and granted scope. If the subject is unknown or has not granted any consent sessions yet, the endpoint returns an empty JSON array with status code 200 OK.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::o_auth2_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let subject = "subject_example"; // String | The subject to list the consent sessions for.
+    let page_size = None; // i64 | Items per Page  This is the number of items per page to return. For details on pagination please head over to the [pagination documentation](https://www.ory.com/docs/ecosystem/api-design#pagination). (optional)
+    let page_token = None; // String | Next Page Token  The next page token. For details on pagination please head over to the [pagination documentation](https://www.ory.com/docs/ecosystem/api-design#pagination). (optional)
+    let login_session_id = None; // String | The login session id to list the consent sessions for. (optional)
+    match o_auth2_api::list_o_auth2_consent_sessions(&configuration, subject, page_size, page_token, login_session_id).await {
+        Ok(response) => println!("OAuth2Api::list_o_auth2_consent_sessions: {:?}", response),
+        Err(error) => eprintln!("Error calling OAuth2Api::list_o_auth2_consent_sessions: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -567,6 +883,26 @@ List Trusted OAuth2 JWT Bearer Grant Type Issuers
 
 Use this endpoint to list all trusted JWT Bearer Grant Type Issuers.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::o_auth2_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let page_size = None; // i64 | Items per Page  This is the number of items per page to return. For details on pagination please head over to the [pagination documentation](https://www.ory.com/docs/ecosystem/api-design#pagination). (optional)
+    let page_token = None; // String | Next Page Token  The next page token. For details on pagination please head over to the [pagination documentation](https://www.ory.com/docs/ecosystem/api-design#pagination). (optional)
+    let issuer = None; // String | If optional \"issuer\" is supplied, only jwt-bearer grants with this issuer will be returned. (optional)
+    match o_auth2_api::list_trusted_o_auth2_jwt_grant_issuers(&configuration, page_size, page_token, issuer).await {
+        Ok(response) => println!("OAuth2Api::list_trusted_o_auth2_jwt_grant_issuers: {:?}", response),
+        Err(error) => eprintln!("Error calling OAuth2Api::list_trusted_o_auth2_jwt_grant_issuers: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -599,6 +935,23 @@ OAuth 2.0 Authorize Endpoint
 
 Use open source libraries to perform OAuth 2.0 and OpenID Connect available for any programming language. You can find a list of libraries at https://oauth.net/code/  This endpoint should not be used via the Ory SDK and is only included for technical reasons. Instead, use one of the libraries linked above.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::o_auth2_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    match o_auth2_api::o_auth2_authorize(&configuration).await {
+        Ok(response) => println!("OAuth2Api::o_auth2_authorize: {:?}", response),
+        Err(error) => eprintln!("Error calling OAuth2Api::o_auth2_authorize: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 This endpoint does not need any parameter.
@@ -626,6 +979,23 @@ The OAuth 2.0 Device Authorize Endpoint
 
 This endpoint is not documented here because you should never use your own implementation to perform OAuth2 flows. OAuth2 is a very popular protocol and a library for your programming language will exist.  To learn more about this flow please refer to the specification: https://tools.ietf.org/html/rfc8628
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::o_auth2_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    match o_auth2_api::o_auth2_device_flow(&configuration).await {
+        Ok(response) => println!("OAuth2Api::o_auth2_device_flow: {:?}", response),
+        Err(error) => eprintln!("Error calling OAuth2Api::o_auth2_device_flow: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 This endpoint does not need any parameter.
@@ -652,6 +1022,28 @@ No authorization required
 The OAuth 2.0 Token Endpoint
 
 Use open source libraries to perform OAuth 2.0 and OpenID Connect available for any programming language. You can find a list of libraries here https://oauth.net/code/  This endpoint should not be used via the Ory SDK and is only included for technical reasons. Instead, use one of the libraries linked above.
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::o_auth2_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let grant_type = "grant_type_example"; // String
+    let client_id = None; // String (optional)
+    let code = None; // String (optional)
+    let redirect_uri = None; // String (optional)
+    let refresh_token = None; // String (optional)
+    match o_auth2_api::oauth2_token_exchange(&configuration, grant_type, client_id, code, redirect_uri, refresh_token).await {
+        Ok(response) => println!("OAuth2Api::oauth2_token_exchange: {:?}", response),
+        Err(error) => eprintln!("Error calling OAuth2Api::oauth2_token_exchange: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -687,6 +1079,25 @@ Patch OAuth 2.0 Client
 
 Patch an existing OAuth 2.0 Client using JSON Patch. If you update `client_secret`, the secret will be updated and returned via the API. This is the only time you will be able to retrieve the client secret. Passing a new `client_secret` will clear all rotated secrets.  To perform a seamless client secret rotation, use the `rotateOAuth2ClientSecret` endpoint instead.  OAuth 2.0 clients are used to perform OAuth 2.0 and OpenID Connect flows. Usually, OAuth 2.0 clients are generated for applications which want to consume your OAuth 2.0 or OpenID Connect capabilities.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::o_auth2_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let id = "id_example"; // String | The id of the OAuth 2.0 Client.
+    let json_patch = Default::default(); // Vec<models::JsonPatch> | OAuth 2.0 Client JSON Patch Body
+    match o_auth2_api::patch_o_auth2_client(&configuration, id, json_patch).await {
+        Ok(response) => println!("OAuth2Api::patch_o_auth2_client: {:?}", response),
+        Err(error) => eprintln!("Error calling OAuth2Api::patch_o_auth2_client: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -718,6 +1129,23 @@ OAuth 2.0 Device Verification Endpoint
 
 This is the device user verification endpoint. The user is redirected here when trying to log in using the device flow.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::o_auth2_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    match o_auth2_api::perform_o_auth2_device_verification_flow(&configuration).await {
+        Ok(response) => println!("OAuth2Api::perform_o_auth2_device_verification_flow: {:?}", response),
+        Err(error) => eprintln!("Error calling OAuth2Api::perform_o_auth2_device_verification_flow: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 This endpoint does not need any parameter.
@@ -744,6 +1172,25 @@ No authorization required
 Reject OAuth 2.0 Consent Request
 
 When an authorization code, hybrid, or implicit OAuth 2.0 Flow is initiated, Ory asks the login provider to authenticate the subject and then tell Ory now about it. If the subject authenticated, he/she must now be asked if the OAuth 2.0 Client which initiated the flow should be allowed to access the resources on the subject's behalf.  The consent challenge is appended to the consent provider's URL to which the subject's user-agent (browser) is redirected to. The consent provider uses that challenge to fetch information on the OAuth2 request and then tells Ory if the subject accepted or rejected the request.  This endpoint tells Ory that the subject has not authorized the OAuth 2.0 client to access resources on his/her behalf. The consent provider must include a reason why the consent was not granted.  The response contains a redirect URL which the consent provider should redirect the user-agent to.  The default consent provider is available via the Ory Managed Account Experience. To customize the consent provider, please head over to the OAuth 2.0 documentation.
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::o_auth2_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let consent_challenge = "consent_challenge_example"; // String | OAuth 2.0 Consent Request Challenge
+    let reject_o_auth2_request = Some(Default::default()); // RejectOAuth2Request (optional)
+    match o_auth2_api::reject_o_auth2_consent_request(&configuration, consent_challenge, reject_o_auth2_request).await {
+        Ok(response) => println!("OAuth2Api::reject_o_auth2_consent_request: {:?}", response),
+        Err(error) => eprintln!("Error calling OAuth2Api::reject_o_auth2_consent_request: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -776,6 +1223,25 @@ Reject OAuth 2.0 Login Request
 
 When an authorization code, hybrid, or implicit OAuth 2.0 Flow is initiated, Ory asks the login provider to authenticate the subject and then tell the Ory OAuth2 Service about it.  The authentication challenge is appended to the login provider URL to which the subject's user-agent (browser) is redirected to. The login provider uses that challenge to fetch information on the OAuth2 request and then accept or reject the requested authentication process.  This endpoint tells Ory that the subject has not authenticated and includes a reason why the authentication was denied.  The response contains a redirect URL which the login provider should redirect the user-agent to.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::o_auth2_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let login_challenge = "login_challenge_example"; // String | OAuth 2.0 Login Request Challenge
+    let reject_o_auth2_request = Some(Default::default()); // RejectOAuth2Request (optional)
+    match o_auth2_api::reject_o_auth2_login_request(&configuration, login_challenge, reject_o_auth2_request).await {
+        Ok(response) => println!("OAuth2Api::reject_o_auth2_login_request: {:?}", response),
+        Err(error) => eprintln!("Error calling OAuth2Api::reject_o_auth2_login_request: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -807,6 +1273,24 @@ Reject OAuth 2.0 Session Logout Request
 
 When a user or an application requests Ory OAuth 2.0 to remove the session state of a subject, this endpoint is used to deny that logout request. No HTTP request body is required.  The response is empty as the logout provider has to chose what action to perform next.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::o_auth2_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let logout_challenge = "logout_challenge_example"; // String
+    match o_auth2_api::reject_o_auth2_logout_request(&configuration, logout_challenge).await {
+        Ok(_) => println!("OAuth2Api::reject_o_auth2_logout_request"),
+        Err(error) => eprintln!("Error calling OAuth2Api::reject_o_auth2_logout_request: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -836,6 +1320,27 @@ Name | Type | Description  | Required | Notes
 Revoke OAuth 2.0 Consent Sessions of a Subject
 
 This endpoint revokes a subject's granted consent sessions and invalidates all associated OAuth 2.0 Access Tokens. You may also only revoke sessions for a specific OAuth 2.0 Client ID.
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::o_auth2_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let subject = None; // String | OAuth 2.0 Consent Subject  The subject whose consent sessions should be deleted. (optional)
+    let client = None; // String | OAuth 2.0 Client ID  If set, deletes only those consent sessions that have been granted to the specified OAuth 2.0 Client ID. (optional)
+    let consent_request_id = None; // String | Consent Request ID  If set, revoke all token chains derived from this particular consent request ID. (optional)
+    let all = None; // bool | Revoke All Consent Sessions  If set to `true` deletes all consent sessions by the Subject that have been granted. (optional)
+    match o_auth2_api::revoke_o_auth2_consent_sessions(&configuration, subject, client, consent_request_id, all).await {
+        Ok(_) => println!("OAuth2Api::revoke_o_auth2_consent_sessions"),
+        Err(error) => eprintln!("Error calling OAuth2Api::revoke_o_auth2_consent_sessions: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -870,6 +1375,25 @@ Revokes OAuth 2.0 Login Sessions by either a Subject or a SessionID
 
 This endpoint invalidates authentication sessions. After revoking the authentication session(s), the subject has to re-authenticate at the Ory OAuth2 Provider. This endpoint does not invalidate any tokens.  If you send the subject in a query param, all authentication sessions that belong to that subject are revoked. No OpenID Connect Front- or Back-channel logout is performed in this case.  Alternatively, you can send a SessionID via `sid` query param, in which case, only the session that is connected to that SessionID is revoked. OpenID Connect Back-channel logout is performed in this case.  When using Ory for the identity provider, the login provider will also invalidate the session cookie.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::o_auth2_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let subject = None; // String | OAuth 2.0 Subject  The subject to revoke authentication sessions for. (optional)
+    let sid = None; // String | Login Session ID  The login session to revoke. (optional)
+    match o_auth2_api::revoke_o_auth2_login_sessions(&configuration, subject, sid).await {
+        Ok(_) => println!("OAuth2Api::revoke_o_auth2_login_sessions"),
+        Err(error) => eprintln!("Error calling OAuth2Api::revoke_o_auth2_login_sessions: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -900,6 +1424,26 @@ Name | Type | Description  | Required | Notes
 Revoke OAuth 2.0 Access or Refresh Token
 
 Revoking a token (both access and refresh) means that the tokens will be invalid. A revoked access token can no longer be used to make access requests, and a revoked refresh token can no longer be used to refresh an access token. Revoking a refresh token also invalidates the access token that was created with it. A token may only be revoked by the client the token was generated for.
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::o_auth2_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let token = "token_example"; // String
+    let client_id = None; // String (optional)
+    let client_secret = None; // String (optional)
+    match o_auth2_api::revoke_o_auth2_token(&configuration, token, client_id, client_secret).await {
+        Ok(_) => println!("OAuth2Api::revoke_o_auth2_token"),
+        Err(error) => eprintln!("Error calling OAuth2Api::revoke_o_auth2_token: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -933,6 +1477,24 @@ Rotate OAuth 2.0 Client Secret
 
 Rotates an OAuth 2.0 client's secrets. The old secret will remain valid for authentication, allowing for zero-downtime secret rotations. A new secret will be generated and returned in the response.  Up to five rotated secrets are retained. Use the `deleteRotatedOAuth2ClientSecrets` endpoint to remove old rotated secrets when they are no longer needed.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::o_auth2_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let id = "id_example"; // String | OAuth 2.0 Client ID
+    match o_auth2_api::rotate_o_auth2_client_secret(&configuration, id).await {
+        Ok(response) => println!("OAuth2Api::rotate_o_auth2_client_secret: {:?}", response),
+        Err(error) => eprintln!("Error calling OAuth2Api::rotate_o_auth2_client_secret: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -962,6 +1524,25 @@ Name | Type | Description  | Required | Notes
 Set OAuth 2.0 Client
 
 Replaces an existing OAuth 2.0 Client with the payload you send. If you pass `client_secret` the secret is used, otherwise the existing secret is used. Rotated secrets will be cleared if you pass a new `client_secret`.  If set, the secret is echoed in the response. It is not possible to retrieve it later on.  To perform a seamless client secret rotation, use the `rotateOAuth2ClientSecret` endpoint instead.  OAuth 2.0 Clients are used to perform OAuth 2.0 and OpenID Connect flows. Usually, OAuth 2.0 clients are generated for applications which want to consume your OAuth 2.0 or OpenID Connect capabilities.
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::o_auth2_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let id = "id_example"; // String | OAuth 2.0 Client ID
+    let o_auth2_client = Default::default(); // OAuth2Client | OAuth 2.0 Client Request Body
+    match o_auth2_api::set_o_auth2_client(&configuration, id, o_auth2_client).await {
+        Ok(response) => println!("OAuth2Api::set_o_auth2_client: {:?}", response),
+        Err(error) => eprintln!("Error calling OAuth2Api::set_o_auth2_client: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -994,6 +1575,25 @@ Set OAuth2 Client Token Lifespans
 
 Set lifespans of different token types issued for this OAuth 2.0 client. Does not modify other fields.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::o_auth2_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let id = "id_example"; // String | OAuth 2.0 Client ID
+    let o_auth2_client_token_lifespans = Some(Default::default()); // OAuth2ClientTokenLifespans (optional)
+    match o_auth2_api::set_o_auth2_client_lifespans(&configuration, id, o_auth2_client_token_lifespans).await {
+        Ok(response) => println!("OAuth2Api::set_o_auth2_client_lifespans: {:?}", response),
+        Err(error) => eprintln!("Error calling OAuth2Api::set_o_auth2_client_lifespans: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -1024,6 +1624,24 @@ Name | Type | Description  | Required | Notes
 Trust OAuth2 JWT Bearer Grant Type Issuer
 
 Use this endpoint to establish a trust relationship for a JWT issuer to perform JSON Web Token (JWT) Profile for OAuth 2.0 Client Authentication and Authorization Grants [RFC7523](https://datatracker.ietf.org/doc/html/rfc7523).
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::o_auth2_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let trust_o_auth2_jwt_grant_issuer = Some(Default::default()); // TrustOAuth2JwtGrantIssuer (optional)
+    match o_auth2_api::trust_o_auth2_jwt_grant_issuer(&configuration, trust_o_auth2_jwt_grant_issuer).await {
+        Ok(response) => println!("OAuth2Api::trust_o_auth2_jwt_grant_issuer: {:?}", response),
+        Err(error) => eprintln!("Error calling OAuth2Api::trust_o_auth2_jwt_grant_issuer: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 

--- a/clients/client/rust/docs/OidcApi.md
+++ b/clients/client/rust/docs/OidcApi.md
@@ -31,7 +31,6 @@ use ory_client::apis::oidc_api;
 #[tokio::main]
 async fn main() {
     let mut configuration = Configuration::new();
-    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
     let o_auth2_client = Default::default(); // OAuth2Client | Dynamic Client Registration Request Body
     match oidc_api::create_oidc_dynamic_client(&configuration, o_auth2_client).await {
         Ok(response) => println!("OidcApi::create_oidc_dynamic_client: {:?}", response),
@@ -79,7 +78,6 @@ use ory_client::apis::oidc_api;
 #[tokio::main]
 async fn main() {
     let mut configuration = Configuration::new();
-    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
     let create_verifiable_credential_request_body = Some(Default::default()); // CreateVerifiableCredentialRequestBody (optional)
     match oidc_api::create_verifiable_credential(&configuration, create_verifiable_credential_request_body).await {
         Ok(response) => println!("OidcApi::create_verifiable_credential: {:?}", response),
@@ -175,7 +173,6 @@ use ory_client::apis::oidc_api;
 #[tokio::main]
 async fn main() {
     let mut configuration = Configuration::new();
-    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
     match oidc_api::discover_oidc_configuration(&configuration).await {
         Ok(response) => println!("OidcApi::discover_oidc_configuration: {:?}", response),
         Err(error) => eprintln!("Error calling OidcApi::discover_oidc_configuration: {:?}", error),
@@ -311,7 +308,6 @@ use ory_client::apis::oidc_api;
 #[tokio::main]
 async fn main() {
     let mut configuration = Configuration::new();
-    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
     match oidc_api::revoke_oidc_session(&configuration).await {
         Ok(_) => println!("OidcApi::revoke_oidc_session"),
         Err(error) => eprintln!("Error calling OidcApi::revoke_oidc_session: {:?}", error),

--- a/clients/client/rust/docs/OidcApi.md
+++ b/clients/client/rust/docs/OidcApi.md
@@ -22,6 +22,24 @@ Register OAuth2 Client using OpenID Dynamic Client Registration
 
 This endpoint behaves like the administrative counterpart (`createOAuth2Client`) but is capable of facing the public internet directly and can be used in self-service. It implements the OpenID Connect Dynamic Client Registration Protocol. This feature needs to be enabled in the configuration. This endpoint is disabled by default. It can be enabled by an administrator.  Please note that using this endpoint you are not able to choose the `client_secret` nor the `client_id` as those values will be server generated when specifying `token_endpoint_auth_method` as `client_secret_basic` or `client_secret_post`.  The `client_secret` will be returned in the response and you will not be able to retrieve it later on. Write the secret down and keep it somewhere safe.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::oidc_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let o_auth2_client = Default::default(); // OAuth2Client | Dynamic Client Registration Request Body
+    match oidc_api::create_oidc_dynamic_client(&configuration, o_auth2_client).await {
+        Ok(response) => println!("OidcApi::create_oidc_dynamic_client: {:?}", response),
+        Err(error) => eprintln!("Error calling OidcApi::create_oidc_dynamic_client: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -51,6 +69,24 @@ No authorization required
 Issues a Verifiable Credential
 
 This endpoint creates a verifiable credential that attests that the user authenticated with the provided access token owns a certain public/private key pair.  More information can be found at https://openid.net/specs/openid-connect-userinfo-vc-1_0.html.
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::oidc_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let create_verifiable_credential_request_body = Some(Default::default()); // CreateVerifiableCredentialRequestBody (optional)
+    match oidc_api::create_verifiable_credential(&configuration, create_verifiable_credential_request_body).await {
+        Ok(response) => println!("OidcApi::create_verifiable_credential: {:?}", response),
+        Err(error) => eprintln!("Error calling OidcApi::create_verifiable_credential: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -82,6 +118,24 @@ Delete OAuth 2.0 Client using the OpenID Dynamic Client Registration Management 
 
 This endpoint behaves like the administrative counterpart (`deleteOAuth2Client`) but is capable of facing the public internet directly and can be used in self-service. It implements the OpenID Connect Dynamic Client Registration Protocol. This feature needs to be enabled in the configuration. This endpoint is disabled by default. It can be enabled by an administrator.  To use this endpoint, you will need to present the client's authentication credentials. If the OAuth2 Client uses the Token Endpoint Authentication Method `client_secret_post`, you need to present the client secret in the URL query. If it uses `client_secret_basic`, present the Client ID and the Client Secret in the Authorization header.  OAuth 2.0 clients are used to perform OAuth 2.0 and OpenID Connect flows. Usually, OAuth 2.0 clients are generated for applications which want to consume your OAuth 2.0 or OpenID Connect capabilities.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::oidc_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let id = "id_example"; // String | The id of the OAuth 2.0 Client.
+    match oidc_api::delete_oidc_dynamic_client(&configuration, id).await {
+        Ok(_) => println!("OidcApi::delete_oidc_dynamic_client"),
+        Err(error) => eprintln!("Error calling OidcApi::delete_oidc_dynamic_client: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -112,6 +166,23 @@ OpenID Connect Discovery
 
 A mechanism for an OpenID Connect Relying Party to discover the End-User's OpenID Provider and obtain information needed to interact with it, including its OAuth 2.0 endpoint locations.  Popular libraries for OpenID Connect clients include oidc-client-js (JavaScript), go-oidc (Golang), and others. For a full list of clients go here: https://openid.net/developers/certified/
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::oidc_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    match oidc_api::discover_oidc_configuration(&configuration).await {
+        Ok(response) => println!("OidcApi::discover_oidc_configuration: {:?}", response),
+        Err(error) => eprintln!("Error calling OidcApi::discover_oidc_configuration: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 This endpoint does not need any parameter.
@@ -138,6 +209,24 @@ No authorization required
 Get OAuth2 Client using OpenID Dynamic Client Registration
 
 This endpoint behaves like the administrative counterpart (`getOAuth2Client`) but is capable of facing the public internet directly and can be used in self-service. It implements the OpenID Connect Dynamic Client Registration Protocol.  To use this endpoint, you will need to present the client's authentication credentials. If the OAuth2 Client uses the Token Endpoint Authentication Method `client_secret_post`, you need to present the client secret in the URL query. If it uses `client_secret_basic`, present the Client ID and the Client Secret in the Authorization header.
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::oidc_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let id = "id_example"; // String | The id of the OAuth 2.0 Client.
+    match oidc_api::get_oidc_dynamic_client(&configuration, id).await {
+        Ok(response) => println!("OidcApi::get_oidc_dynamic_client: {:?}", response),
+        Err(error) => eprintln!("Error calling OidcApi::get_oidc_dynamic_client: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -169,6 +258,23 @@ OpenID Connect Userinfo
 
 This endpoint returns the payload of the ID Token, including `session.id_token` values, of the provided OAuth 2.0 Access Token's consent request.  In the case of authentication error, a WWW-Authenticate header might be set in the response with more information about the error. See [the spec](https://datatracker.ietf.org/doc/html/rfc6750#section-3) for more details about header format.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::oidc_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    match oidc_api::get_oidc_user_info(&configuration).await {
+        Ok(response) => println!("OidcApi::get_oidc_user_info: {:?}", response),
+        Err(error) => eprintln!("Error calling OidcApi::get_oidc_user_info: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 This endpoint does not need any parameter.
@@ -196,6 +302,23 @@ OpenID Connect Front- and Back-channel Enabled Logout
 
 This endpoint initiates and completes user logout at the Ory OAuth2 & OpenID provider and initiates OpenID Connect Front- / Back-channel logout:  https://openid.net/specs/openid-connect-frontchannel-1_0.html https://openid.net/specs/openid-connect-backchannel-1_0.html  Back-channel logout is performed asynchronously and does not affect logout flow.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::oidc_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    match oidc_api::revoke_oidc_session(&configuration).await {
+        Ok(_) => println!("OidcApi::revoke_oidc_session"),
+        Err(error) => eprintln!("Error calling OidcApi::revoke_oidc_session: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 This endpoint does not need any parameter.
@@ -222,6 +345,25 @@ No authorization required
 Set OAuth2 Client using OpenID Dynamic Client Registration
 
 This endpoint behaves like the administrative counterpart (`setOAuth2Client`) but is capable of facing the public internet directly to be used by third parties. It implements the OpenID Connect Dynamic Client Registration Protocol.  This feature is disabled per default. It can be enabled by a system administrator.  If you pass `client_secret` the secret is used, otherwise the existing secret is used. If set, the secret is echoed in the response. It is not possible to retrieve it later on.  To use this endpoint, you will need to present the client's authentication credentials. If the OAuth2 Client uses the Token Endpoint Authentication Method `client_secret_post`, you need to present the client secret in the URL query. If it uses `client_secret_basic`, present the Client ID and the Client Secret in the Authorization header.  OAuth 2.0 clients are used to perform OAuth 2.0 and OpenID Connect flows. Usually, OAuth 2.0 clients are generated for applications which want to consume your OAuth 2.0 or OpenID Connect capabilities.
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::oidc_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let id = "id_example"; // String | OAuth 2.0 Client ID
+    let o_auth2_client = Default::default(); // OAuth2Client | OAuth 2.0 Client Request Body
+    match oidc_api::set_oidc_dynamic_client(&configuration, id, o_auth2_client).await {
+        Ok(response) => println!("OidcApi::set_oidc_dynamic_client: {:?}", response),
+        Err(error) => eprintln!("Error calling OidcApi::set_oidc_dynamic_client: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 

--- a/clients/client/rust/docs/PermissionApi.md
+++ b/clients/client/rust/docs/PermissionApi.md
@@ -20,6 +20,25 @@ Batch check permissions
 
 To learn how relationship tuples and the check works, head over to [the documentation](https://www.ory.com/docs/keto/concepts/api-overview).
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::permission_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let max_depth = None; // i64 (optional)
+    let batch_check_permission_body = Some(Default::default()); // BatchCheckPermissionBody (optional)
+    match permission_api::batch_check_permission(&configuration, max_depth, batch_check_permission_body).await {
+        Ok(response) => println!("PermissionApi::batch_check_permission: {:?}", response),
+        Err(error) => eprintln!("Error calling PermissionApi::batch_check_permission: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -50,6 +69,31 @@ Name | Type | Description  | Required | Notes
 Check a permission
 
 To learn how relationship tuples and the check works, head over to [the documentation](https://www.ory.com/docs/keto/concepts/api-overview).
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::permission_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let namespace = None; // String | Namespace of the Relationship (optional)
+    let object = None; // String | Object of the Relationship (optional)
+    let relation = None; // String | Relation of the Relationship (optional)
+    let subject_id = None; // String | SubjectID of the Relationship (optional)
+    let subject_set_namespace = None; // String | Namespace of the Subject Set (optional)
+    let subject_set_object = None; // String | Object of the Subject Set (optional)
+    let subject_set_relation = None; // String | Relation of the Subject Set (optional)
+    let max_depth = None; // i64 (optional)
+    match permission_api::check_permission(&configuration, namespace, object, relation, subject_id, subject_set_namespace, subject_set_object, subject_set_relation, max_depth).await {
+        Ok(response) => println!("PermissionApi::check_permission: {:?}", response),
+        Err(error) => eprintln!("Error calling PermissionApi::check_permission: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -88,6 +132,31 @@ Check a permission
 
 To learn how relationship tuples and the check works, head over to [the documentation](https://www.ory.com/docs/keto/concepts/api-overview).
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::permission_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let namespace = None; // String | Namespace of the Relationship (optional)
+    let object = None; // String | Object of the Relationship (optional)
+    let relation = None; // String | Relation of the Relationship (optional)
+    let subject_id = None; // String | SubjectID of the Relationship (optional)
+    let subject_set_namespace = None; // String | Namespace of the Subject Set (optional)
+    let subject_set_object = None; // String | Object of the Subject Set (optional)
+    let subject_set_relation = None; // String | Relation of the Subject Set (optional)
+    let max_depth = None; // i64 (optional)
+    match permission_api::check_permission_or_error(&configuration, namespace, object, relation, subject_id, subject_set_namespace, subject_set_object, subject_set_relation, max_depth).await {
+        Ok(response) => println!("PermissionApi::check_permission_or_error: {:?}", response),
+        Err(error) => eprintln!("Error calling PermissionApi::check_permission_or_error: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -125,6 +194,27 @@ Expand a Relationship into permissions.
 
 Use this endpoint to expand a relationship tuple into permissions.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::permission_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let namespace = "namespace_example"; // String | Namespace of the Subject Set
+    let object = "object_example"; // String | Object of the Subject Set
+    let relation = "relation_example"; // String | Relation of the Subject Set
+    let max_depth = None; // i64 (optional)
+    match permission_api::expand_permissions(&configuration, namespace, object, relation, max_depth).await {
+        Ok(response) => println!("PermissionApi::expand_permissions: {:?}", response),
+        Err(error) => eprintln!("Error calling PermissionApi::expand_permissions: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -158,6 +248,25 @@ Check a permission
 
 To learn how relationship tuples and the check works, head over to [the documentation](https://www.ory.com/docs/keto/concepts/api-overview).
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::permission_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let max_depth = None; // i64 (optional)
+    let post_check_permission_body = Some(Default::default()); // PostCheckPermissionBody (optional)
+    match permission_api::post_check_permission(&configuration, max_depth, post_check_permission_body).await {
+        Ok(response) => println!("PermissionApi::post_check_permission: {:?}", response),
+        Err(error) => eprintln!("Error calling PermissionApi::post_check_permission: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -188,6 +297,25 @@ Name | Type | Description  | Required | Notes
 Check a permission
 
 To learn how relationship tuples and the check works, head over to [the documentation](https://www.ory.com/docs/keto/concepts/api-overview).
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::permission_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let max_depth = None; // i64 (optional)
+    let post_check_permission_or_error_body = Some(Default::default()); // PostCheckPermissionOrErrorBody (optional)
+    match permission_api::post_check_permission_or_error(&configuration, max_depth, post_check_permission_or_error_body).await {
+        Ok(response) => println!("PermissionApi::post_check_permission_or_error: {:?}", response),
+        Err(error) => eprintln!("Error calling PermissionApi::post_check_permission_or_error: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 

--- a/clients/client/rust/docs/ProjectApi.md
+++ b/clients/client/rust/docs/ProjectApi.md
@@ -35,6 +35,25 @@ Create an Enterprise SSO Organization
 
 Deprecated: use setProject or patchProjectWithRevision instead  Creates an Enterprise SSO Organization in a project.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::project_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let project_id = "project_id_example"; // String | Project ID  The project's ID.
+    let organization_body = Some(Default::default()); // OrganizationBody (optional)
+    match project_api::create_organization(&configuration, project_id, organization_body).await {
+        Ok(response) => println!("ProjectApi::create_organization: {:?}", response),
+        Err(error) => eprintln!("Error calling ProjectApi::create_organization: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -65,6 +84,26 @@ Name | Type | Description  | Required | Notes
 Create organization onboarding portal link
 
 Create a onboarding portal link for an organization.
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::project_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let project_id = "project_id_example"; // String | Project ID  The project's ID.
+    let organization_id = "organization_id_example"; // String | Organization ID  The Organization's ID.
+    let create_organization_onboarding_portal_link_body = Some(Default::default()); // CreateOrganizationOnboardingPortalLinkBody (optional)
+    match project_api::create_organization_onboarding_portal_link(&configuration, project_id, organization_id, create_organization_onboarding_portal_link_body).await {
+        Ok(response) => println!("ProjectApi::create_organization_onboarding_portal_link: {:?}", response),
+        Err(error) => eprintln!("Error calling ProjectApi::create_organization_onboarding_portal_link: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -98,6 +137,24 @@ Create a Project
 
 Creates a new project.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::project_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let create_project_body = Some(Default::default()); // CreateProjectBody (optional)
+    match project_api::create_project(&configuration, create_project_body).await {
+        Ok(response) => println!("ProjectApi::create_project: {:?}", response),
+        Err(error) => eprintln!("Error calling ProjectApi::create_project: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -127,6 +184,25 @@ Name | Type | Description  | Required | Notes
 Create project API key
 
 Create an API key for a project.
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::project_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let project = "project_example"; // String | The Project ID or Project slug
+    let create_project_api_key_body = Some(Default::default()); // CreateProjectApiKeyBody (optional)
+    match project_api::create_project_api_key(&configuration, project, create_project_api_key_body).await {
+        Ok(response) => println!("ProjectApi::create_project_api_key: {:?}", response),
+        Err(error) => eprintln!("Error calling ProjectApi::create_project_api_key: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -159,6 +235,25 @@ Delete Enterprise SSO Organization
 
 Deprecated: use setProject or patchProjectWithRevision instead  Irrecoverably deletes an Enterprise SSO Organization in a project by its ID.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::project_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let project_id = "project_id_example"; // String | Project ID  The project's ID.
+    let organization_id = "organization_id_example"; // String | Organization ID  The Organization's ID.
+    match project_api::delete_organization(&configuration, project_id, organization_id).await {
+        Ok(_) => println!("ProjectApi::delete_organization"),
+        Err(error) => eprintln!("Error calling ProjectApi::delete_organization: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -189,6 +284,26 @@ Name | Type | Description  | Required | Notes
 Delete an organization onboarding portal link
 
 Deletes a onboarding portal link for an organization.
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::project_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let project_id = "project_id_example"; // String
+    let organization_id = "organization_id_example"; // String
+    let onboarding_portal_link_id = "onboarding_portal_link_id_example"; // String
+    match project_api::delete_organization_onboarding_portal_link(&configuration, project_id, organization_id, onboarding_portal_link_id).await {
+        Ok(_) => println!("ProjectApi::delete_organization_onboarding_portal_link"),
+        Err(error) => eprintln!("Error calling ProjectApi::delete_organization_onboarding_portal_link: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -222,6 +337,25 @@ Delete project API key
 
 Deletes an API key and immediately removes it.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::project_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let project = "project_example"; // String | The Project ID or Project slug
+    let token_id = "token_id_example"; // String | The Token ID
+    match project_api::delete_project_api_key(&configuration, project, token_id).await {
+        Ok(_) => println!("ProjectApi::delete_project_api_key"),
+        Err(error) => eprintln!("Error calling ProjectApi::delete_project_api_key: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -252,6 +386,25 @@ Name | Type | Description  | Required | Notes
 Get Enterprise SSO Organization by ID
 
 Deprecated: use getProject instead  Retrieves an Enterprise SSO Organization for a project by its ID
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::project_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let project_id = "project_id_example"; // String | Project ID  The project's ID.
+    let organization_id = "organization_id_example"; // String | Organization ID  The Organization's ID.
+    match project_api::get_organization(&configuration, project_id, organization_id).await {
+        Ok(response) => println!("ProjectApi::get_organization: {:?}", response),
+        Err(error) => eprintln!("Error calling ProjectApi::get_organization: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -284,6 +437,25 @@ Get the organization onboarding portal links
 
 Retrieves the organization onboarding portal links.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::project_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let project_id = "project_id_example"; // String | Project ID  The project's ID.
+    let organization_id = "organization_id_example"; // String | Organization ID  The Organization's ID.
+    match project_api::get_organization_onboarding_portal_links(&configuration, project_id, organization_id).await {
+        Ok(response) => println!("ProjectApi::get_organization_onboarding_portal_links: {:?}", response),
+        Err(error) => eprintln!("Error calling ProjectApi::get_organization_onboarding_portal_links: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -315,6 +487,24 @@ Get a Project
 
 Get a project you have access to by its ID.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::project_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let project_id = "project_id_example"; // String | Project ID  The project's ID.
+    match project_api::get_project(&configuration, project_id).await {
+        Ok(response) => println!("ProjectApi::get_project: {:?}", response),
+        Err(error) => eprintln!("Error calling ProjectApi::get_project: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -345,6 +535,24 @@ Get all members associated with this project
 
 This endpoint requires the user to be a member of the project with the role `OWNER` or `DEVELOPER`.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::project_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let project = "project_example"; // String
+    match project_api::get_project_members(&configuration, project).await {
+        Ok(response) => println!("ProjectApi::get_project_members: {:?}", response),
+        Err(error) => eprintln!("Error calling ProjectApi::get_project_members: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -374,6 +582,27 @@ Name | Type | Description  | Required | Notes
 List all Enterprise SSO organizations
 
 Deprecated: use getProject instead  Lists all Enterprise SSO organizations in a project.
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::project_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let project_id = "project_id_example"; // String | Project ID  The project's ID.
+    let page_size = None; // i64 | Items per Page  This is the number of items per page to return. For details on pagination please head over to the [pagination documentation](https://www.ory.com/docs/ecosystem/api-design#pagination). (optional)
+    let page_token = None; // String | Next Page Token  The next page token. For details on pagination please head over to the [pagination documentation](https://www.ory.com/docs/ecosystem/api-design#pagination). (optional)
+    let domain = None; // String | Domain  If set, only organizations with that domain will be returned. (optional)
+    match project_api::list_organizations(&configuration, project_id, page_size, page_token, domain).await {
+        Ok(response) => println!("ProjectApi::list_organizations: {:?}", response),
+        Err(error) => eprintln!("Error calling ProjectApi::list_organizations: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -408,6 +637,24 @@ List a project's API keys
 
 A list of all the project's API keys.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::project_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let project = "project_example"; // String | The Project ID or Project slug
+    match project_api::list_project_api_keys(&configuration, project).await {
+        Ok(response) => println!("ProjectApi::list_project_api_keys: {:?}", response),
+        Err(error) => eprintln!("Error calling ProjectApi::list_project_api_keys: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -438,6 +685,23 @@ List All Projects
 
 Lists all projects you have access to.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::project_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    match project_api::list_projects(&configuration).await {
+        Ok(response) => println!("ProjectApi::list_projects: {:?}", response),
+        Err(error) => eprintln!("Error calling ProjectApi::list_projects: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 This endpoint does not need any parameter.
@@ -464,6 +728,25 @@ This endpoint does not need any parameter.
 Patch an Ory Network Project Configuration
 
 Deprecated: Use the `patchProjectWithRevision` endpoint instead to specify the exact revision the patch was generated for.  This endpoints allows you to patch individual Ory Network project configuration keys for Ory's services (identity, permission, ...). The configuration format is fully compatible with the open source projects for the respective services (e.g. Ory Kratos for Identity, Ory Keto for Permissions).  This endpoint expects the `version` key to be set in the payload. If it is unset, it will try to import the config as if it is from the most recent version.  If you have an older version of a configuration, you should set the version key in the payload!  While this endpoint is able to process all configuration items related to features (e.g. password reset), it does not support operational configuration items (e.g. port, tracing, logging) otherwise available in the open source.  For configuration items that can not be translated to the Ory Network, this endpoint will return a list of warnings to help you understand which parts of your config could not be processed.
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::project_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let project_id = "project_id_example"; // String | Project ID  The project's ID.
+    let json_patch = Some(Default::default()); // Vec<models::JsonPatch> (optional)
+    match project_api::patch_project(&configuration, project_id, json_patch).await {
+        Ok(response) => println!("ProjectApi::patch_project: {:?}", response),
+        Err(error) => eprintln!("Error calling ProjectApi::patch_project: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -495,6 +778,26 @@ Name | Type | Description  | Required | Notes
 Patch an Ory Network Project Configuration based on a revision ID
 
 This endpoints allows you to patch individual Ory Network Project configuration keys for Ory's services (identity, permission, ...). The configuration format is fully compatible with the open source projects for the respective services (e.g. Ory Kratos for Identity, Ory Keto for Permissions).  This endpoint expects the `version` key to be set in the payload. If it is unset, it will try to import the config as if it is from the most recent version.  If you have an older version of a configuration, you should set the version key in the payload!  While this endpoint is able to process all configuration items related to features (e.g. password reset), it does not support operational configuration items (e.g. port, tracing, logging) otherwise available in the open source.  For configuration items that can not be translated to the Ory Network, this endpoint will return a list of warnings to help you understand which parts of your config could not be processed.
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::project_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let project_id = "project_id_example"; // String | Project ID  The project's ID.
+    let revision_id = "revision_id_example"; // String | Revision ID  The revision ID that this patch was generated for.
+    let json_patch = Some(Default::default()); // Vec<models::JsonPatch> (optional)
+    match project_api::patch_project_with_revision(&configuration, project_id, revision_id, json_patch).await {
+        Ok(response) => println!("ProjectApi::patch_project_with_revision: {:?}", response),
+        Err(error) => eprintln!("Error calling ProjectApi::patch_project_with_revision: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -528,6 +831,24 @@ Irrecoverably purge a project
 
 !! Use with extreme caution !!  Using this API endpoint you can purge (completely delete) a project and its data. This action can not be undone and will delete ALL your data.  Calling this endpoint will additionally delete custom domains and other related data.  If the project is linked to a subscription, the subscription needs to be unlinked first.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::project_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let project_id = "project_id_example"; // String | Project ID  The project's ID.
+    match project_api::purge_project(&configuration, project_id).await {
+        Ok(_) => println!("ProjectApi::purge_project"),
+        Err(error) => eprintln!("Error calling ProjectApi::purge_project: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -557,6 +878,25 @@ Name | Type | Description  | Required | Notes
 Remove a member associated with this project
 
 This also sets their invite status to `REMOVED`. This endpoint requires the user to be a member of the project with the role `OWNER`.
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::project_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let project = "project_example"; // String
+    let member = "member_example"; // String
+    match project_api::remove_project_member(&configuration, project, member).await {
+        Ok(_) => println!("ProjectApi::remove_project_member"),
+        Err(error) => eprintln!("Error calling ProjectApi::remove_project_member: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -589,6 +929,25 @@ Update an Ory Network Project Configuration
 
 This endpoints allows you to update the Ory Network project configuration for individual services (identity, permission, ...). The configuration is fully compatible with the open source projects for the respective services (e.g. Ory Kratos for Identity, Ory Keto for Permissions).  This endpoint expects the `version` key to be set in the payload. If it is unset, it will try to import the config as if it is from the most recent version.  If you have an older version of a configuration, you should set the version key in the payload!  While this endpoint is able to process all configuration items related to features (e.g. password reset), it does not support operational configuration items (e.g. port, tracing, logging) otherwise available in the open source.  For configuration items that can not be translated to the Ory Network, this endpoint will return a list of warnings to help you understand which parts of your config could not be processed.  Be aware that updating any service's configuration will completely override your current configuration for that service!
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::project_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let project_id = "project_id_example"; // String | Project ID  The project's ID.
+    let set_project = Some(Default::default()); // SetProject (optional)
+    match project_api::set_project(&configuration, project_id, set_project).await {
+        Ok(response) => println!("ProjectApi::set_project: {:?}", response),
+        Err(error) => eprintln!("Error calling ProjectApi::set_project: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -619,6 +978,26 @@ Name | Type | Description  | Required | Notes
 Update an Enterprise SSO Organization
 
 Deprecated: use setProject or patchProjectWithRevision instead  Updates an Enterprise SSO Organization in a project by its ID.
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::project_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let project_id = "project_id_example"; // String | Project ID  The project's ID.
+    let organization_id = "organization_id_example"; // String | Organization ID  The Organization's ID.
+    let organization_body = Some(Default::default()); // OrganizationBody (optional)
+    match project_api::update_organization(&configuration, project_id, organization_id, organization_body).await {
+        Ok(response) => println!("ProjectApi::update_organization: {:?}", response),
+        Err(error) => eprintln!("Error calling ProjectApi::update_organization: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -651,6 +1030,27 @@ Name | Type | Description  | Required | Notes
 Update organization onboarding portal link
 
 Update a onboarding portal link for an organization.
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::project_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let project_id = "project_id_example"; // String | Project ID  The project's ID.
+    let organization_id = "organization_id_example"; // String | Organization ID  The Organization's ID.
+    let onboarding_portal_link_id = "onboarding_portal_link_id_example"; // String
+    let update_organization_onboarding_portal_link_body = Some(Default::default()); // UpdateOrganizationOnboardingPortalLinkBody (optional)
+    match project_api::update_organization_onboarding_portal_link(&configuration, project_id, organization_id, onboarding_portal_link_id, update_organization_onboarding_portal_link_body).await {
+        Ok(response) => println!("ProjectApi::update_organization_onboarding_portal_link: {:?}", response),
+        Err(error) => eprintln!("Error calling ProjectApi::update_organization_onboarding_portal_link: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 

--- a/clients/client/rust/docs/RelationshipApi.md
+++ b/clients/client/rust/docs/RelationshipApi.md
@@ -20,6 +20,24 @@ Check the syntax of an OPL file
 
 The OPL file is expected in the body of the request.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::relationship_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let body = Some(Default::default()); // String (optional)
+    match relationship_api::check_opl_syntax(&configuration, body).await {
+        Ok(response) => println!("RelationshipApi::check_opl_syntax: {:?}", response),
+        Err(error) => eprintln!("Error calling RelationshipApi::check_opl_syntax: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -50,6 +68,24 @@ Create a Relationship
 
 Use this endpoint to create a relationship.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::relationship_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let create_relationship_body = Some(Default::default()); // CreateRelationshipBody (optional)
+    match relationship_api::create_relationship(&configuration, create_relationship_body).await {
+        Ok(response) => println!("RelationshipApi::create_relationship: {:?}", response),
+        Err(error) => eprintln!("Error calling RelationshipApi::create_relationship: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -79,6 +115,30 @@ Name | Type | Description  | Required | Notes
 Delete Relationships
 
 Use this endpoint to delete relationships
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::relationship_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let namespace = None; // String | Namespace of the Relationship (optional)
+    let object = None; // String | Object of the Relationship (optional)
+    let relation = None; // String | Relation of the Relationship (optional)
+    let subject_id = None; // String | SubjectID of the Relationship (optional)
+    let subject_set_namespace = None; // String | Namespace of the Subject Set (optional)
+    let subject_set_object = None; // String | Object of the Subject Set (optional)
+    let subject_set_relation = None; // String | Relation of the Subject Set (optional)
+    match relationship_api::delete_relationships(&configuration, namespace, object, relation, subject_id, subject_set_namespace, subject_set_object, subject_set_relation).await {
+        Ok(_) => println!("RelationshipApi::delete_relationships"),
+        Err(error) => eprintln!("Error calling RelationshipApi::delete_relationships: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -115,6 +175,32 @@ Name | Type | Description  | Required | Notes
 Query relationships
 
 Get all relationships that match the query. Only the namespace field is required.
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::relationship_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let page_size = None; // i64 | Items per Page  This is the number of items per page to return. For details on pagination please head over to the [pagination documentation](https://www.ory.com/docs/ecosystem/api-design#pagination). (optional)
+    let page_token = None; // String | Next Page Token  The next page token. For details on pagination please head over to the [pagination documentation](https://www.ory.com/docs/ecosystem/api-design#pagination). (optional)
+    let namespace = None; // String | Namespace of the Relationship (optional)
+    let object = None; // String | Object of the Relationship (optional)
+    let relation = None; // String | Relation of the Relationship (optional)
+    let subject_id = None; // String | SubjectID of the Relationship (optional)
+    let subject_set_namespace = None; // String | Namespace of the Subject Set (optional)
+    let subject_set_object = None; // String | Object of the Subject Set (optional)
+    let subject_set_relation = None; // String | Relation of the Subject Set (optional)
+    match relationship_api::get_relationships(&configuration, page_size, page_token, namespace, object, relation, subject_id, subject_set_namespace, subject_set_object, subject_set_relation).await {
+        Ok(response) => println!("RelationshipApi::get_relationships: {:?}", response),
+        Err(error) => eprintln!("Error calling RelationshipApi::get_relationships: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -154,6 +240,23 @@ Query namespaces
 
 Get all namespaces
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::relationship_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    match relationship_api::list_relationship_namespaces(&configuration).await {
+        Ok(response) => println!("RelationshipApi::list_relationship_namespaces: {:?}", response),
+        Err(error) => eprintln!("Error calling RelationshipApi::list_relationship_namespaces: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 This endpoint does not need any parameter.
@@ -180,6 +283,24 @@ This endpoint does not need any parameter.
 Patch Multiple Relationships
 
 Use this endpoint to patch one or more relationships.
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::relationship_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let relationship_patch = Some(Default::default()); // Vec<models::RelationshipPatch> (optional)
+    match relationship_api::patch_relationships(&configuration, relationship_patch).await {
+        Ok(_) => println!("RelationshipApi::patch_relationships"),
+        Err(error) => eprintln!("Error calling RelationshipApi::patch_relationships: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 

--- a/clients/client/rust/docs/WellknownApi.md
+++ b/clients/client/rust/docs/WellknownApi.md
@@ -24,7 +24,6 @@ use ory_client::apis::wellknown_api;
 #[tokio::main]
 async fn main() {
     let mut configuration = Configuration::new();
-    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
     match wellknown_api::discover_json_web_keys(&configuration).await {
         Ok(response) => println!("WellknownApi::discover_json_web_keys: {:?}", response),
         Err(error) => eprintln!("Error calling WellknownApi::discover_json_web_keys: {:?}", error),

--- a/clients/client/rust/docs/WellknownApi.md
+++ b/clients/client/rust/docs/WellknownApi.md
@@ -15,6 +15,23 @@ Discover Well-Known JSON Web Keys
 
 This endpoint returns JSON Web Keys required to verifying OpenID Connect ID Tokens and, if enabled, OAuth 2.0 JWT Access Tokens. This endpoint can be used with client libraries like [node-jwks-rsa](https://github.com/auth0/node-jwks-rsa) among others.  Adding custom keys requires first creating a keyset via the createJsonWebKeySet operation, and then configuring the webfinger.jwks.broadcast_keys configuration value to include the keyset name.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::wellknown_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    match wellknown_api::discover_json_web_keys(&configuration).await {
+        Ok(response) => println!("WellknownApi::discover_json_web_keys: {:?}", response),
+        Err(error) => eprintln!("Error calling WellknownApi::discover_json_web_keys: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 This endpoint does not need any parameter.

--- a/clients/client/rust/docs/WorkspaceApi.md
+++ b/clients/client/rust/docs/WorkspaceApi.md
@@ -20,6 +20,24 @@ Method | HTTP request | Description
 > models::Workspace create_workspace(create_workspace_body)
 Create a new workspace
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::workspace_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let create_workspace_body = Some(Default::default()); // CreateWorkspaceBody (optional)
+    match workspace_api::create_workspace(&configuration, create_workspace_body).await {
+        Ok(response) => println!("WorkspaceApi::create_workspace: {:?}", response),
+        Err(error) => eprintln!("Error calling WorkspaceApi::create_workspace: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -49,6 +67,25 @@ Name | Type | Description  | Required | Notes
 Create workspace API key
 
 Create an API key for a workspace.
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::workspace_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let workspace = "workspace_example"; // String | The Workspace ID
+    let create_workspace_api_key_body = Some(Default::default()); // CreateWorkspaceApiKeyBody (optional)
+    match workspace_api::create_workspace_api_key(&configuration, workspace, create_workspace_api_key_body).await {
+        Ok(response) => println!("WorkspaceApi::create_workspace_api_key: {:?}", response),
+        Err(error) => eprintln!("Error calling WorkspaceApi::create_workspace_api_key: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -81,6 +118,25 @@ Delete workspace API key
 
 Deletes an API key and immediately removes it.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::workspace_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let workspace = "workspace_example"; // String | The Workspace ID or Workspace slug
+    let token_id = "token_id_example"; // String | The Token ID
+    match workspace_api::delete_workspace_api_key(&configuration, workspace, token_id).await {
+        Ok(_) => println!("WorkspaceApi::delete_workspace_api_key"),
+        Err(error) => eprintln!("Error calling WorkspaceApi::delete_workspace_api_key: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -112,6 +168,24 @@ Get a workspace
 
 Any workspace member can access this endpoint.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::workspace_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let workspace = "workspace_example"; // String
+    match workspace_api::get_workspace(&configuration, workspace).await {
+        Ok(response) => println!("WorkspaceApi::get_workspace: {:?}", response),
+        Err(error) => eprintln!("Error calling WorkspaceApi::get_workspace: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -141,6 +215,24 @@ Name | Type | Description  | Required | Notes
 List a workspace's API keys
 
 A list of all the workspace's API keys.
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::workspace_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let workspace = "workspace_example"; // String | The Workspace ID or Workspace slug
+    match workspace_api::list_workspace_api_keys(&configuration, workspace).await {
+        Ok(response) => println!("WorkspaceApi::list_workspace_api_keys: {:?}", response),
+        Err(error) => eprintln!("Error calling WorkspaceApi::list_workspace_api_keys: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -172,6 +264,24 @@ List all projects of a workspace
 
 Any workspace member can access this endpoint.
 
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::workspace_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let workspace = "workspace_example"; // String
+    match workspace_api::list_workspace_projects(&configuration, workspace).await {
+        Ok(response) => println!("WorkspaceApi::list_workspace_projects: {:?}", response),
+        Err(error) => eprintln!("Error calling WorkspaceApi::list_workspace_projects: {:?}", error),
+    }
+}
+```
+
 ### Parameters
 
 
@@ -199,6 +309,25 @@ Name | Type | Description  | Required | Notes
 
 > models::ListWorkspaces list_workspaces(page_size, page_token)
 List workspaces the user is a member of
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::workspace_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let page_size = None; // i64 | Items per Page  This is the number of items per page to return. For details on pagination please head over to the [pagination documentation](https://www.ory.com/docs/ecosystem/api-design#pagination). (optional)
+    let page_token = None; // String | Next Page Token  The next page token. For details on pagination please head over to the [pagination documentation](https://www.ory.com/docs/ecosystem/api-design#pagination). (optional)
+    match workspace_api::list_workspaces(&configuration, page_size, page_token).await {
+        Ok(response) => println!("WorkspaceApi::list_workspaces: {:?}", response),
+        Err(error) => eprintln!("Error calling WorkspaceApi::list_workspaces: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 
@@ -230,6 +359,25 @@ Name | Type | Description  | Required | Notes
 Update an workspace
 
 Workspace members with the role `OWNER` can access this endpoint.
+
+### Example
+
+```rust
+use ory_client::apis::configuration::Configuration;
+use ory_client::apis::workspace_api;
+
+#[tokio::main]
+async fn main() {
+    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+    let workspace = "workspace_example"; // String
+    let update_workspace_body = Some(Default::default()); // UpdateWorkspaceBody (optional)
+    match workspace_api::update_workspace(&configuration, workspace, update_workspace_body).await {
+        Ok(response) => println!("WorkspaceApi::update_workspace: {:?}", response),
+        Err(error) => eprintln!("Error calling WorkspaceApi::update_workspace: {:?}", error),
+    }
+}
+```
 
 ### Parameters
 

--- a/config/client/dotnet-templates/libraries/generichost/api_doc.mustache
+++ b/config/client/dotnet-templates/libraries/generichost/api_doc.mustache
@@ -1,0 +1,108 @@
+# {{packageName}}.{{apiPackage}}.{{classname}}{{#description}}
+{{.}}{{/description}}
+
+All URIs are relative to *{{{basePath}}}*
+
+| Method | HTTP request | Description |
+|--------|--------------|-------------|
+{{#operations}}
+{{#operation}}
+| [**{{operationId}}**]({{classname}}.md#{{operationIdLowerCase}}) | **{{httpMethod}}** {{path}} | {{summary}} |
+{{/operation}}
+{{/operations}}
+
+{{#operations}}
+{{#operation}}
+<a id="{{{operationIdLowerCase}}}"></a>
+# **{{{operationId}}}**
+> Task&lt;{{interfacePrefix}}{{operationId}}ApiResponse&gt; {{operationId}}Async({{>OperationSignature}})
+
+{{{summary}}}{{#notes}}
+
+{{{.}}}{{/notes}}
+
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using {{packageName}}.{{apiPackage}};
+using {{packageName}}.Client;
+using {{packageName}}.Extensions;
+using {{packageName}}.{{modelPackage}};
+
+namespace Example
+{
+    public class {{operationId}}Example
+    {
+        public static async Task Main()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .Configure{{apiName}}((context, services, options) =>
+                {
+                    {{#hasAuthMethods}}
+                    // Available token types are ApiKeyToken, BasicToken, BearerToken, HttpSigningToken, and OAuthToken.
+                    options.AddTokens(new BearerToken("<your token>"));
+                    {{/hasAuthMethods}}
+                    options.Add{{apiName}}HttpClients();
+                })
+                .Build();
+
+            var api = host.Services.GetRequiredService<{{interfacePrefix}}{{classname}}>();
+            {{#allParams}}
+            {{^required}}Option<{{/required}}{{>OperationDataType}}{{^required}}>{{/required}} {{paramName}} = default{{nrt!}}; // {{{description}}}{{^required}} (optional){{/required}}
+            {{/allParams}}
+            {{#responses}}
+            {{#-first}}
+            {{#dataType}}
+            var response = await api.{{operationId}}Async({{#allParams}}{{paramName}}{{^-last}}, {{/-last}}{{/allParams}});
+            {{{.}}}{{nrt?}} model = response.{{vendorExtensions.x-http-status}}();
+            {{/dataType}}
+            {{^dataType}}
+            await api.{{operationId}}Async({{#allParams}}{{paramName}}{{^-last}}, {{/-last}}{{/allParams}});
+            {{/dataType}}
+            {{/-first}}
+            {{/responses}}
+        }
+    }
+}
+```
+
+### Parameters
+{{^allParams}}This endpoint does not need any parameter.{{/allParams}}{{#allParams}}{{#-last}}
+| Name | Type | Description | Notes |
+|------|------|-------------|-------|
+{{/-last}}
+{{/allParams}}
+{{#allParams}}
+| **{{paramName}}** | {{#isFile}}**{{dataType}}**{{/isFile}}{{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}{{^isFile}}[**{{dataType}}**](../models/{{#isContainer}}{{baseType}}{{/isContainer}}{{^isContainer}}{{dataType}}{{/isContainer}}.md){{/isFile}}{{/isPrimitiveType}} | {{description}} | {{^required}}[optional] {{/required}}{{#defaultValue}}[default to {{.}}]{{/defaultValue}} |
+{{/allParams}}
+
+### Return type
+
+{{#returnType}}{{#returnTypeIsPrimitive}}**{{{returnType}}}**{{/returnTypeIsPrimitive}}{{^returnTypeIsPrimitive}}[**{{returnType}}**](../models/{{returnBaseType}}.md){{/returnTypeIsPrimitive}}{{/returnType}}{{^returnType}}void (empty response body){{/returnType}}
+
+### Authorization
+
+{{^authMethods}}No authorization required{{/authMethods}}{{#authMethods}}[{{{name}}}](../../README.md#{{{name}}}){{^-last}}, {{/-last}}{{/authMethods}}
+
+### HTTP request headers
+
+ - **Content-Type**: {{#consumes}}{{{mediaType}}}{{^-last}}, {{/-last}}{{/consumes}}{{^consumes}}Not defined{{/consumes}}
+ - **Accept**: {{#produces}}{{{mediaType}}}{{^-last}}, {{/-last}}{{/produces}}{{^produces}}Not defined{{/produces}}
+
+{{#responses.0}}
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+{{#responses}}
+| **{{code}}** | {{message}} | {{#headers}} * {{baseName}} - {{description}} <br> {{/headers}}{{^headers.0}} - {{/headers.0}} |
+{{/responses}}
+{{/responses.0}}
+
+[[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
+
+{{/operation}}
+{{/operations}}

--- a/config/client/rust-templates/api_doc.mustache
+++ b/config/client/rust-templates/api_doc.mustache
@@ -29,7 +29,8 @@ use {{{externCrateName}}}::apis::{{{classFilename}}};
 async fn main() {
 {{/supportAsync}}{{^supportAsync}}fn main() {
 {{/supportAsync}}    let mut configuration = Configuration::new();
-    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+{{#hasAuthMethods}}    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+{{/hasAuthMethods}}
 {{#allParams}}
     let {{{paramName}}} = {{#isBodyParam}}{{^required}}Some({{/required}}Default::default(){{^required}}){{/required}}{{/isBodyParam}}{{^isBodyParam}}{{^required}}None{{/required}}{{#required}}{{#isString}}"{{{example}}}"{{/isString}}{{^isString}}{{#isUuid}}"{{{example}}}"{{/isUuid}}{{^isUuid}}{{#isBoolean}}{{{example}}}{{/isBoolean}}{{#isInteger}}{{{example}}}{{/isInteger}}{{#isNumber}}{{{example}}}{{/isNumber}}{{^isBoolean}}{{^isInteger}}{{^isNumber}}Default::default(){{/isNumber}}{{/isInteger}}{{/isBoolean}}{{/isUuid}}{{/isString}}{{/required}}{{/isBodyParam}}; // {{{dataType}}}{{#description}} | {{{description}}}{{/description}}{{^required}} (optional){{/required}}
 {{/allParams}}

--- a/config/client/rust-templates/api_doc.mustache
+++ b/config/client/rust-templates/api_doc.mustache
@@ -1,0 +1,68 @@
+# {{{invokerPackage}}}\{{{classname}}}{{#description}}
+
+{{{.}}}{{/description}}
+
+All URIs are relative to *{{{basePath}}}*
+
+Method | HTTP request | Description
+------------- | ------------- | -------------
+{{#operations}}{{#operation}}[**{{{operationId}}}**]({{{classname}}}.md#{{{operationId}}}) | **{{{httpMethod}}}** {{{path}}} | {{{summary}}}
+{{/operation}}{{/operations}}
+
+{{#operations}}
+{{#operation}}
+
+## {{{operationId}}}
+
+> {{#returnType}}{{{.}}} {{/returnType}}{{{operationId}}}({{#allParams}}{{{paramName}}}{{^-last}}, {{/-last}}{{/allParams}})
+{{{summary}}}{{#notes}}
+
+{{{.}}}{{/notes}}
+
+### Example
+
+```rust
+use {{{externCrateName}}}::apis::configuration::Configuration;
+use {{{externCrateName}}}::apis::{{{classFilename}}};
+
+{{#supportAsync}}#[tokio::main]
+async fn main() {
+{{/supportAsync}}{{^supportAsync}}fn main() {
+{{/supportAsync}}    let mut configuration = Configuration::new();
+    configuration.bearer_access_token = Some("ory_pat_...".to_owned());
+{{#allParams}}
+    let {{{paramName}}} = {{#isBodyParam}}{{^required}}Some({{/required}}Default::default(){{^required}}){{/required}}{{/isBodyParam}}{{^isBodyParam}}{{^required}}None{{/required}}{{#required}}{{#isString}}"{{{example}}}"{{/isString}}{{^isString}}{{#isUuid}}"{{{example}}}"{{/isUuid}}{{^isUuid}}{{#isBoolean}}{{{example}}}{{/isBoolean}}{{#isInteger}}{{{example}}}{{/isInteger}}{{#isNumber}}{{{example}}}{{/isNumber}}{{^isBoolean}}{{^isInteger}}{{^isNumber}}Default::default(){{/isNumber}}{{/isInteger}}{{/isBoolean}}{{/isUuid}}{{/isString}}{{/required}}{{/isBodyParam}}; // {{{dataType}}}{{#description}} | {{{description}}}{{/description}}{{^required}} (optional){{/required}}
+{{/allParams}}
+    match {{{classFilename}}}::{{{operationId}}}(&configuration{{#allParams}}, {{{paramName}}}{{/allParams}}){{#supportAsync}}.await{{/supportAsync}} {
+        Ok({{#returnType}}response{{/returnType}}{{^returnType}}_{{/returnType}}) => println!("{{classname}}::{{operationId}}{{#returnType}}: {:?}{{/returnType}}"{{#returnType}}, response{{/returnType}}),
+        Err(error) => eprintln!("Error calling {{classname}}::{{operationId}}: {:?}", error),
+    }
+}
+```
+
+### Parameters
+
+{{^allParams}}This endpoint does not need any parameter.{{/allParams}}{{#allParams}}{{#-last}}
+Name | Type | Description  | Required | Notes
+------------- | ------------- | ------------- | ------------- | -------------{{/-last}}{{/allParams}}
+{{#allParams}}
+**{{{paramName}}}** | {{^required}}Option<{{/required}}{{#required}}{{#isNullable}}Option<{{/isNullable}}{{/required}}{{#isPrimitiveType}}**{{{dataType}}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{{dataType}}}**]({{{baseType}}}.md){{/isPrimitiveType}}{{^required}}>{{/required}}{{#required}}{{#isNullable}}>{{/isNullable}}{{/required}} | {{{description}}} | {{#required}}[required]{{/required}} |{{#defaultValue}}[default to {{{.}}}]{{/defaultValue}}
+{{/allParams}}
+
+### Return type
+
+{{#returnType}}{{#returnTypeIsPrimitive}}**{{{returnType}}}**{{/returnTypeIsPrimitive}}{{^returnTypeIsPrimitive}}[**{{{returnType}}}**]({{{returnBaseType}}}.md){{/returnTypeIsPrimitive}}{{/returnType}}{{^returnType}} (empty response body){{/returnType}}
+
+### Authorization
+
+{{^authMethods}}No authorization required{{/authMethods}}{{#authMethods}}[{{{name}}}](../README.md#{{{name}}}){{^-last}}, {{/-last}}{{/authMethods}}
+
+### HTTP request headers
+
+- **Content-Type**: {{#consumes}}{{{mediaType}}}{{^-last}}, {{/-last}}{{/consumes}}{{^consumes}}Not defined{{/consumes}}
+- **Accept**: {{#produces}}{{{mediaType}}}{{^-last}}, {{/-last}}{{/produces}}{{^produces}}Not defined{{/produces}}
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+{{/operation}}
+{{/operations}}

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -283,6 +283,7 @@ rust () {
   npx @openapitools/openapi-generator-cli@2.25.2 version-manager set 7.17.0
   npx @openapitools/openapi-generator-cli@2.25.2 generate -i "${SPEC_FILE}" \
     -g rust \
+    -t ./config/client/rust-templates \
     -o "$dir" \
     --git-user-id ory \
     --git-repo-id sdk \


### PR DESCRIPTION
The Rust and .NET clients were the only ones whose generated docs carried no usage examples. Both now emit 171 `###Example` blocks, matching TypeScript, Go, Python, Java, and PHP.

Neither gap was configurable and each needed a custom `api_doc.mustache`:

- **Rust** — the upstream template has no `### Example` section at all, and no generator option adds one. Adds `config/client/rust-templates/` and passes `-t` in `generate.sh`.
- **.NET** — the csharp generator has a single API doc template shared by all libraries, and wraps its example in `{{^useGenericHost}}`. The generator defaults to `generichost`, so the block never rendered. The override goes under `libraries/generichost/`, which resolves ahead of the embedded root template.

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.com/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got approval (please contact
      [security@ory.com](mailto:security@ory.com)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added the necessary documentation within the code base (if
      appropriate).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated .NET API references with asynchronous methods, cancellation support, optional parameters, and modern usage examples.
  * Added comprehensive Rust examples covering API operations, authentication, asynchronous calls, and error handling.
  * Corrected model and authorization links across generated documentation.
  * Removed hard-coded access tokens from Rust examples where authentication is not required.
* **Chores**
  * Added templates for consistent .NET and Rust API documentation generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->