### PR TITLE
fix: accept unknown enum values in the Go SDK

### DIFF
--- a/config/client/go-templates/model_enum.mustache
+++ b/config/client/go-templates/model_enum.mustache
@@ -26,6 +26,12 @@ var Allowed{{{classname}}}EnumValues = []{{{classname}}}{
 }
 
 func (v *{{{classname}}}) UnmarshalJSON(src []byte) error {
+	{{! ORY OVERRIDE: reject null, which json.Unmarshal would otherwise accept. }}
+	// A nullable field decodes null before reaching this method, so null here is
+	// invalid. json.Unmarshal would silently leave the zero value instead.
+	if string(src) == "null" {
+		return fmt.Errorf("null is not a valid {{classname}}")
+	}
 	var value {{{format}}}{{^format}}{{dataType}}{{/format}}
 	err := json.Unmarshal(src, &value)
 	if err != nil {

--- a/config/client/go-templates/model_enum.mustache
+++ b/config/client/go-templates/model_enum.mustache
@@ -1,0 +1,102 @@
+{{! ORY OVERRIDE of the stock go/model_enum.mustache. Identical to the upstream }}
+{{! template except for UnmarshalJSON, which accepts values outside the generated }}
+{{! set so that new server-side enum members do not break older SDK builds. The go }}
+{{! generator exposes no option for this. See UnmarshalJSON below.                 }}
+// {{{classname}}} {{{description}}}{{^description}}the model '{{{classname}}}'{{/description}}
+type {{{classname}}} {{{format}}}{{^format}}{{dataType}}{{/format}}
+
+// List of {{{name}}}
+const (
+	{{#allowableValues}}
+	{{#enumVars}}
+	{{^-first}}
+	{{/-first}}
+	{{#enumClassPrefix}}{{{classname.toUpperCase}}}_{{/enumClassPrefix}}{{name}} {{{classname}}} = {{{value}}}
+	{{/enumVars}}
+	{{/allowableValues}}
+)
+
+// All allowed values of {{{classname}}} enum
+var Allowed{{{classname}}}EnumValues = []{{{classname}}}{
+	{{#allowableValues}}
+	{{#enumVars}}
+	{{{value}}},
+	{{/enumVars}}
+	{{/allowableValues}}
+}
+
+func (v *{{{classname}}}) UnmarshalJSON(src []byte) error {
+	var value {{{format}}}{{^format}}{{dataType}}{{/format}}
+	err := json.Unmarshal(src, &value)
+	if err != nil {
+		return err
+	}
+	{{! ORY OVERRIDE: keep unrecognized values instead of returning an error. }}
+	// Unknown values are kept verbatim: adding a value to this enum is a
+	// backwards-compatible server change. Use IsValid to detect values that this
+	// version of the SDK does not know.
+	*v = {{{classname}}}(value)
+	return nil
+}
+
+// New{{{classname}}}FromValue returns a pointer to a valid {{{classname}}}
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func New{{{classname}}}FromValue(v {{{format}}}{{^format}}{{dataType}}{{/format}}) (*{{{classname}}}, error) {
+	ev := {{{classname}}}(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for {{{classname}}}: valid values are %v", v, Allowed{{{classname}}}EnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v {{{classname}}}) IsValid() bool {
+	for _, existing := range Allowed{{{classname}}}EnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
+}
+
+// Ptr returns reference to {{{name}}} value
+func (v {{{classname}}}) Ptr() *{{{classname}}} {
+	return &v
+}
+
+type Nullable{{{classname}}} struct {
+	value *{{{classname}}}
+	isSet bool
+}
+
+func (v Nullable{{classname}}) Get() *{{classname}} {
+	return v.value
+}
+
+func (v *Nullable{{classname}}) Set(val *{{classname}}) {
+	v.value = val
+	v.isSet = true
+}
+
+func (v Nullable{{classname}}) IsSet() bool {
+	return v.isSet
+}
+
+func (v *Nullable{{classname}}) Unset() {
+	v.value = nil
+	v.isSet = false
+}
+
+func NewNullable{{classname}}(val *{{classname}}) *Nullable{{classname}} {
+	return &Nullable{{classname}}{value: val, isSet: true}
+}
+
+func (v Nullable{{{classname}}}) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.value)
+}
+
+func (v *Nullable{{{classname}}}) UnmarshalJSON(src []byte) error {
+	v.isSet = true
+	return json.Unmarshal(src, &v.value)
+}

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -206,6 +206,7 @@ golang () {
   npx @openapitools/openapi-generator-cli@2.25.2 version-manager set 7.17.0
   npx @openapitools/openapi-generator-cli@2.25.2 generate -i "${SPEC_FILE}" \
     -g go \
+    -t ./config/client/go-templates \
     -o "$dir" \
     --git-user-id ory \
     --git-repo-id "${name}" \


### PR DESCRIPTION
The generated Go clients reject any enum value that was not present in the spec they were built from: `UnmarshalJSON` returns `"%v is not a valid X"` and the **entire response** fails to decode, not just that one field.

Adding a value to an enum is a backwards-compatible server change, so it should not break clients built against an older spec. Today it does.

## What changed

`config/client/go-templates/model_enum.mustache` overrides the generator's `model_enum` template so `UnmarshalJSON` keeps the value it was given:

```go
	// Unknown values are kept verbatim: adding a value to this enum is a
	// backwards-compatible server change. Use IsValid to detect values that this
	// version of the SDK does not know.
	*v = CourierMessageStatus(value)
	return nil
```

`AllowedXEnumValues`, `NewXFromValue` and `IsValid` are unchanged, so this is source-compatible — callers that want to detect an unknown value call `IsValid`. Because a Go string enum keeps its raw value, an unknown value also survives a decode and encode round trip. A type mismatch is still an error.

This mirrors the csharp override in `config/client/dotnet-templates` added in #476, and uses the same `{{! ORY OVERRIDE: ... }}` markers. Go has it easier than C#: a string enum keeps the value it was given, so there is no `Unknown` sentinel and nothing re-serializes as `unknown_default_open_api`.

## Why a template and not a config option

The generator has no option for this. `enumUnknownDefaultCase` is not it — on the Go generator it appends an `UNKNOWN_DEFAULT_OPEN_API` member whose value is the literal string `"11184809"`, and `UnmarshalJSON` still rejects everything outside the generated set.

## Verification

Each Go client was generated twice from the same spec and config, once stock and once with `-t`, and the outputs diffed. The override touches only enum models and nothing else:

| Client | Enum models changed |
| --- | --- |
| `ory/client-go` | 18 |
| `ory/kratos-client-go` | 8 |
| `ory/keto-client-go` | 0 |
| `ory/oathkeeper-client-go` | 0 |

All four build clean. Against a real `ory/client-go` build, `"aal9"` now unmarshals into `Session.AuthenticatorAssuranceLevel`, `IsValid()` reports `false`, the value survives a decode → encode → decode round trip, and `42` still fails as a type error.

The committed clients under `clients/` are not regenerated here — they pick this up on the next spec release, same as #476.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GQc5BR7akP66wRN1CkbvX8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Generated Go clients now provide richer enum support, including validation, constructors, pointers, nullable values, and JSON serialization.
  - Enum values received from JSON are preserved even when they are not among the predefined values.

- **Improvements**
  - Go client generation now uses the enhanced project templates for consistent enum behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->